### PR TITLE
Revamp API wrapper code

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -8,9 +8,8 @@ Web UI version numbers should always match the corresponding version of LBRY App
 
 ## [Unreleased]
 ### Added
-  *
-  *
-  *
+  * You can now make API calls directly on the lbry module, e.g. lbry.peer_list()
+  * New-style API calls return promises instead of using callbacks
 
 ### Changed
   *

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -10,6 +10,7 @@ Web UI version numbers should always match the corresponding version of LBRY App
 ### Added
   * You can now make API calls directly on the lbry module, e.g. lbry.peer_list()
   * New-style API calls return promises instead of using callbacks
+  * Wherever possible, use outpoints for unique IDs instead of names or SD hashes
 
 ### Changed
   *

--- a/ui/js/component/file-actions.js
+++ b/ui/js/component/file-actions.js
@@ -68,7 +68,7 @@ let FileActionsRow = React.createClass({
 
   propTypes: {
     streamName: React.PropTypes.string,
-    sdHash: React.PropTypes.string.isRequired,
+    outpoint: React.PropTypes.string.isRequired,
     metadata: React.PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.string]),
   },
   getInitialState: function() {
@@ -145,11 +145,7 @@ let FileActionsRow = React.createClass({
     });
   },
   handleRemoveConfirmed: function() {
-    if (this.props.streamName) {
-      lbry.removeFile(this.props.sdHash, this.props.streamName, this.state.deleteChecked);
-    } else {
-      alert('this file cannot be deleted because lbry is a retarded piece of shit');
-    }
+    lbry.removeFile(this.props.outpoint, this.state.deleteChecked);
     this.setState({
       modal: null,
       fileInfo: false,
@@ -163,12 +159,12 @@ let FileActionsRow = React.createClass({
   },
   componentDidMount: function() {
     this._isMounted = true;
-    this._fileInfoSubscribeId = lbry.fileInfoSubscribe(this.props.sdHash, this.onFileInfoUpdate);
+    this._fileInfoSubscribeId = lbry.fileInfoSubscribe(this.props.outpoint, this.onFileInfoUpdate);
   },
   componentWillUnmount: function() {
     this._isMounted = false;
     if (this._fileInfoSubscribeId) {
-      lbry.fileInfoUnsubscribe(this.props.sdHash, this._fileInfoSubscribeId);
+      lbry.fileInfoUnsubscribe(this.props.outpoint, this._fileInfoSubscribeId);
     }
   },
   render: function() {
@@ -238,7 +234,7 @@ export let FileActions = React.createClass({
 
   propTypes: {
     streamName: React.PropTypes.string,
-    sdHash: React.PropTypes.string.isRequired,
+    outpoint: React.PropTypes.string.isRequired,
     metadata: React.PropTypes.oneOfType([React.PropTypes.object, React.PropTypes.string]),
   },
   getInitialState: function() {
@@ -262,7 +258,7 @@ export let FileActions = React.createClass({
   },
   componentDidMount: function() {
     this._isMounted = true;
-    this._fileInfoSubscribeId = lbry.fileInfoSubscribe(this.props.sdHash, this.onFileInfoUpdate);
+    this._fileInfoSubscribeId = lbry.fileInfoSubscribe(this.props.outpoint, this.onFileInfoUpdate);
     lbry.getStreamAvailability(this.props.streamName, (availability) => {
       if (this._isMounted) {
         this.setState({
@@ -290,7 +286,7 @@ export let FileActions = React.createClass({
     return (<section className="file-actions">
       {
         fileInfo || this.state.available || this.state.forceShowActions
-          ? <FileActionsRow sdHash={this.props.sdHash} metadata={this.props.metadata} streamName={this.props.streamName} />
+          ? <FileActionsRow outpoint={this.props.outpoint} metadata={this.props.metadata} streamName={this.props.streamName} />
           : <div>
               <div className="button-set-item empty">This file is not currently available.</div>
               <ToolTip label="Why?"

--- a/ui/js/component/file-tile.js
+++ b/ui/js/component/file-tile.js
@@ -58,7 +58,7 @@ export let FileTileStream = React.createClass({
 
   propTypes: {
     metadata: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.object]),
-    sdHash: React.PropTypes.string,
+    outpoint: React.PropTypes.string,
     hideOnRemove: React.PropTypes.bool,
     hidePrice: React.PropTypes.bool,
     obscureNsfw: React.PropTypes.bool
@@ -79,12 +79,12 @@ export let FileTileStream = React.createClass({
   componentDidMount: function() {
     this._isMounted = true;
     if (this.props.hideOnRemove) {
-      lbry.fileInfoSubscribe(this.props.sdHash, this.onFileInfoUpdate);
+      lbry.fileInfoSubscribe(this.props.outpoint, this.onFileInfoUpdate);
     }
   },
   componentWillUnmount: function() {
     if (this._fileInfoSubscribeId) {
-      lbry.fileInfoUnsubscribe(this.props.sdHash, this._fileInfoSubscribeId);
+      lbry.fileInfoUnsubscribe(this.props.outpoint, this._fileInfoSubscribeId);
     }
   },
   onFileInfoUpdate: function(fileInfo) {
@@ -135,7 +135,7 @@ export let FileTileStream = React.createClass({
                 </TruncatedText>
               </a>
             </h3>
-            <FileActions streamName={this.props.name} sdHash={this.props.sdHash} metadata={metadata} />
+            <FileActions streamName={this.props.name} outpoint={this.props.outpoint} metadata={metadata} />
             <p className="file-tile__description">
               <TruncatedText lines={3}>
                 {isConfirmed
@@ -168,7 +168,7 @@ export let FileTile = React.createClass({
 
   getInitialState: function() {
     return {
-      sdHash: null,
+      outpoint: null,
       metadata: null
     }
   },
@@ -176,12 +176,12 @@ export let FileTile = React.createClass({
   componentDidMount: function() {
     this._isMounted = true;
 
-    lbry.resolveName(this.props.name, (metadata) => {
-      if (this._isMounted && metadata) {
+    lbry.claim_show({name: this.props.name}).then(({value, txid, nout}) => {
+      if (this._isMounted && value) {
         // In case of a failed lookup, metadata will be null, in which case the component will never display
         this.setState({
-          sdHash: metadata.sources.lbry_sd_hash,
-          metadata: metadata,
+          outpoint: txid + ':' + nout,
+          metadata: value,
         });
       }
     });
@@ -190,10 +190,10 @@ export let FileTile = React.createClass({
     this._isMounted = false;
   },
   render: function() {
-    if (!this.state.metadata || !this.state.sdHash) {
+    if (!this.state.metadata || !this.state.outpoint) {
       return null;
     }
 
-    return <FileTileStream sdHash={this.state.sdHash} metadata={this.state.metadata} {... this.props} />;
+    return <FileTileStream outpoint={this.state.outpoint} metadata={this.state.metadata} {... this.props} />;
   }
 });

--- a/ui/js/jsonrpc.js
+++ b/ui/js/jsonrpc.js
@@ -1,0 +1,69 @@
+const jsonrpc = {};
+
+jsonrpc.call = function (connectionString, method, params, callback, errorCallback, connectFailedCallback, timeout) {
+  var xhr = new XMLHttpRequest;
+  if (typeof connectFailedCallback !== 'undefined') {
+    if (timeout) {
+      xhr.timeout = timeout;
+    }
+
+    xhr.addEventListener('error', function (e) {
+      connectFailedCallback(e);
+    });
+    xhr.addEventListener('timeout', function() {
+      connectFailedCallback(new Error('XMLHttpRequest connection timed out'));
+    })
+  }
+  xhr.addEventListener('load', function() {
+    var response = JSON.parse(xhr.responseText);
+
+    if (response.error) {
+      if (errorCallback) {
+        errorCallback(response.error);
+      } else {
+        var errorEvent = new CustomEvent('unhandledError', {
+          detail: {
+            connectionString: connectionString,
+            method: method,
+            params: params,
+            code: response.error.code,
+            message: response.error.message,
+            data: response.error.data
+          }
+        });
+        document.dispatchEvent(errorEvent)
+      }
+    } else if (callback) {
+      callback(response.result);
+    }
+  });
+
+  if (connectFailedCallback) {
+    xhr.addEventListener('error', function (event) {
+      connectFailedCallback(event);
+    });
+  } else {
+    xhr.addEventListener('error', function (event) {
+      var errorEvent = new CustomEvent('unhandledError', {
+        detail: {
+          connectionString: connectionString,
+          method: method,
+          params: params,
+          code: xhr.status,
+          message: 'Connection to API server failed'
+        }
+      });
+      document.dispatchEvent(errorEvent);
+    });
+  }
+
+  xhr.open('POST', connectionString, true);
+  xhr.send(JSON.stringify({
+    'jsonrpc': '2.0',
+    'method': method,
+    'params': params,
+    'id': 0
+  }));
+};
+
+export default jsonrpc;

--- a/ui/js/jsonrpc.js
+++ b/ui/js/jsonrpc.js
@@ -57,13 +57,17 @@ jsonrpc.call = function (connectionString, method, params, callback, errorCallba
     });
   }
 
+  const counter = parseInt(sessionStorage.getItem('JSONRPCCounter') || 0);
+
   xhr.open('POST', connectionString, true);
   xhr.send(JSON.stringify({
     'jsonrpc': '2.0',
     'method': method,
     'params': params,
-    'id': 0
+    'id': counter,
   }));
+
+  sessionStorage.setItem('JSONRPCCounter', counter + 1);
 };
 
 export default jsonrpc;

--- a/ui/js/lighthouse.js
+++ b/ui/js/lighthouse.js
@@ -1,67 +1,64 @@
 import lbry from './lbry.js';
+import jsonrpc from './jsonrpc.js';
 
-var lighthouse = {
-  _query_timeout: 5000,
-  _max_query_tries: 5,
+const queryTimeout = 5000;
+const maxQueryTries = 5;
+const defaultServers = [
+  'http://lighthouse4.lbry.io:50005',
+  'http://lighthouse5.lbry.io:50005',
+  'http://lighthouse6.lbry.io:50005',
+];
+const path = '/';
 
-  servers: [
-    'http://lighthouse4.lbry.io:50005',
-    'http://lighthouse5.lbry.io:50005',
-    'http://lighthouse6.lbry.io:50005',
-  ],
-  path: '/',
+let server = null;
+let connectTryNum = 0;
 
-  call: function(method, params, callback, errorCallback, connectFailedCallback, timeout) {
-    const handleConnectFailed = function(tryNum=0) {
-      if (tryNum > lighthouse._max_query_tries) {
-        if (connectFailedCallback) {
-          connectFailedCallback();
-        } else {
-          throw new Error(`Could not connect to Lighthouse server. Last server attempted: ${lighthouse.server}`);
-        }
-      } else {
-        lbry.call(method, params, callback, errorCallback, () => { handleConnectFailed(tryNum + 1) }, timeout);
-      }
-    }
+function getServers() {
+  return lbry.getClientSetting('useCustomLighthouseServers')
+    ? lbry.getClientSetting('customLighthouseServers')
+    : defaultServers;
+}
 
-    // Set the Lighthouse server if it hasn't been set yet, or if the current server is not in
-    // the current set of servers (most likely because of a settings change).
-    if (typeof lighthouse.server === 'undefined' || lighthouse.getServers().indexOf(lighthouse.server) == -1) {
-      lighthouse.chooseNewServer();
-    }
-
-    lbry.jsonrpc_call(this.server + this.path, method, params, callback, errorCallback,
-                      () => { handleConnectFailed() }, timeout || lighthouse.query_timeout);
-  },
-
-  getServers: function() {
-    return lbry.getClientSetting('useCustomLighthouseServers')
-      ? lbry.getClientSetting('customLighthouseServers')
-      : lighthouse.servers;
-  },
-
-  chooseNewServer: function() {
-    // Randomly choose a new Lighthouse server and switch to it. If a server is already set, this
-    // will choose a different one (used for switching servers after a failed query).
-    const servers = lighthouse.getServers();
-    let newServerChoices;
-    if (!lighthouse.server) {
-      newServerChoices = servers;
+function call(method, params, callback, errorCallback) {
+  if (connectTryNum > maxQueryTries) {
+    if (connectFailedCallback) {
+      connectFailedCallback();
     } else {
-      newServerChoices = lighthouse.getServers().slice();
-      newServerChoices.splice(newServerChoices.indexOf(lighthouse.server), 1);
+      throw new Error(`Could not connect to Lighthouse server. Last server attempted: ${server}`);
     }
-    lighthouse.server = newServerChoices[Math.round(Math.random() * (newServerChoices.length - 1))];
-  },
-
-  search: function(query, callback, errorCallback, connectFailedCallback, timeout) {
-    lighthouse.call('search', [query], callback, errorCallback, connectFailedCallback, timeout);
-  },
-
-  getSizeForName: function(name, callback, errorCallback, connectFailedCallback, timeout) {
-    lighthouse.call('get_size_for_name', [name], callback, errorCallback, connectFailedCallback, timeout);
   }
-};
 
+  /**
+   * Set the Lighthouse server if it hasn't been set yet, if the current server is not in current
+   * set of servers (most likely because of a settings change), or we're re-trying after a failed
+   * query.
+   */
+  if (!server || !getServers().includes(server) || connectTryNum > 0) {
+    // If there's a current server, filter it out so we get a new one
+    const newServerChoices = server ? getServers().filter((s) => s != server) : getServers();
+    server = newServerChoices[Math.round(Math.random() * (newServerChoices.length - 1))];
+  }
+
+  jsonrpc.call(server + path, method, params, (response) => {
+    connectTryNum = 0;
+    callback(response);
+  }, (error) => {
+    connectTryNum = 0;
+    errorCallback(error);
+  }, () => {
+    connectTryNum++;
+    call(method, params, callback, errorCallback);
+  });
+}
+
+const lighthouse = new Proxy({}, {
+  get: function(target, name) {
+    return function(...params) {
+      return new Promise((resolve, reject) => {
+        call(name, params, resolve, reject);
+      });
+    };
+  },
+});
 
 export default lighthouse;

--- a/ui/js/main.js
+++ b/ui/js/main.js
@@ -9,9 +9,7 @@ lbry.showMenuIfNeeded();
 
 var init = function() {
   window.lbry = lbry;
-  if (lbry.getClientSetting('debug')) {
-    window.lighthouse = lighthouse;
-  }
+  window.lighthouse = lighthouse;
 
   var canvas = document.getElementById('canvas');
   if (window.sessionStorage.getItem('loaded') == 'y') {

--- a/ui/js/page/discover.js
+++ b/ui/js/page/discover.js
@@ -125,7 +125,7 @@ var DiscoverPage = React.createClass({
       query: query,
     });
 
-    lighthouse.search(query, this.searchCallback);
+    lighthouse.search(query).then(this.searchCallback);
   },
 
   componentWillMount: function() {

--- a/ui/js/page/file-list.js
+++ b/ui/js/page/file-list.js
@@ -18,23 +18,15 @@ export let FileListDownloaded = React.createClass({
     this._isMounted = true;
     document.title = "Downloaded Files";
 
-    let publishedFilesSdHashes = [];
-    lbry.getMyClaims((claimInfos) => {
-
+    lbry.claim_list_mine().then((myClaimInfos) => {
       if (!this._isMounted) { return; }
 
-      for (let claimInfo of claimInfos) {
-        let metadata = JSON.parse(claimInfo.value);
-        publishedFilesSdHashes.push(metadata.sources.lbry_sd_hash);
-      }
-
-      lbry.getFilesInfo((fileInfos) => {
+      lbry.file_list().then((fileInfos) => {
         if (!this._isMounted) { return; }
 
+        const myClaimOutpoints = myClaimInfos.map(({txid, nOut}) => txid + ':' + nOut);
         this.setState({
-          fileInfos: fileInfos.filter(({sd_hash}) => {
-            return publishedFilesSdHashes.indexOf(sd_hash) == -1;
-          })
+          fileInfos: fileInfos.filter(({outpoint}) => !myClaimOutpoints.includes(outpoint)),
         });
       });
     });
@@ -74,41 +66,17 @@ export let FileListPublished = React.createClass({
     this._isMounted = true;
     document.title = "Published Files";
 
-    lbry.getMyClaims((claimInfos) => {
-      if (claimInfos.length == 0) {
+    lbry.claim_list_mine().then((claimInfos) => {
+      if (!this._isMounted) { return; }
+
+      lbry.file_list().then((fileInfos) => {
+        if (!this._isMounted) { return; }
+
+        const myClaimOutpoints = claimInfos.map(({txid, nOut}) => txid + ':' + nOut);
         this.setState({
-          fileInfos: [],
+          fileInfos: fileInfos.filter(({outpoint}) => myClaimOutpoints.includes(outpoint)),
         });
-      }
-
-      /**
-       * Build newFileInfos as a sparse array and drop elements in at the same position they
-       * occur in claimInfos, so the order is preserved even if the API calls inside this loop
-       * return out of order.
-       */
-      let newFileInfos = Array(claimInfos.length),
-        claimInfoProcessedCount = 0;
-
-      for (let [i, claimInfo] of claimInfos.entries()) {
-        let metadata = JSON.parse(claimInfo.value);
-        lbry.getFileInfoBySdHash(metadata.sources.lbry_sd_hash, (fileInfo) => {
-          claimInfoProcessedCount++;
-          if (fileInfo !== false) {
-            newFileInfos[i] = fileInfo;
-          }
-          if (claimInfoProcessedCount >= claimInfos.length) {
-            /**
-             * newfileInfos may have gaps from claims that don't have associated files in
-             * lbrynet, so filter out any missing elements
-             */
-            this.setState({
-              fileInfos: newFileInfos.filter(function () {
-                return true
-              }),
-            });
-          }
-        });
-      }
+      });
     });
   },
   render: function () {
@@ -192,15 +160,13 @@ export let FileList = React.createClass({
         seenUris = {};
 
     const fileInfosSorted = this._sortFunctions[this.state.sortBy](this.props.fileInfos);
-    for (let fileInfo of fileInfosSorted) {
-      let {lbry_uri, sd_hash, metadata} = fileInfo;
-
-      if (!metadata || seenUris[lbry_uri]) {
+    for (let {name, outpoint, metadata} of fileInfosSorted) {
+      if (!metadata || seenUris[name]) {
         continue;
       }
 
-      seenUris[lbry_uri] = true;
-      content.push(<FileTileStream key={lbry_uri} name={lbry_uri} hideOnRemove={true} sdHash={sd_hash}
+      seenUris[name] = true;
+      content.push(<FileTileStream key={outpoint} outpoint={outpoint} name={name} hideOnRemove={true}
                                    hidePrice={this.props.hidePrices} metadata={metadata} />);
     }
 

--- a/ui/js/page/show.js
+++ b/ui/js/page/show.js
@@ -19,6 +19,7 @@ var FormatItem = React.createClass({
     claimInfo: React.PropTypes.object,
     cost: React.PropTypes.number,
     name: React.PropTypes.string,
+    outpoint: React.PropTypes.string,
     costIncludesData: React.PropTypes.bool,
   },
   render: function() {
@@ -62,7 +63,7 @@ var FormatItem = React.createClass({
               </tbody>
             </table>
           </section>
-          <FileActions streamName={this.props.name} sdHash={claimInfo.sources.lbry_sd_hash} metadata={claimInfo} />
+          <FileActions streamName={this.props.name} outpoint={this.props.outpoint} metadata={claimInfo} />
           <section>
             <Link href="https://lbry.io/dmca" label="report" className="button-text-help" />
           </section>
@@ -120,9 +121,10 @@ var DetailPage = React.createClass({
   componentWillMount: function() {
     document.title = 'lbry://' + this.props.name;
 
-    lbry.resolveName(this.props.name, (metadata) => {
+    lbry.claim_show({name: this.props.name}, ({name, txid, nout, value}) => {
       this.setState({
-        metadata: metadata,
+        outpoint: txid + ':' + nout,
+        metadata: value,
         nameLookupComplete: true,
       });
     });
@@ -143,12 +145,13 @@ var DetailPage = React.createClass({
     const costIncludesData = this.state.costIncludesData;
     const metadata = this.state.metadata;
     const cost = this.state.cost;
+    const outpoint = this.state.outpoint;
 
     return (
       <main>
         <section className="card">
           {this.state.nameLookupComplete ? (
-            <FormatsSection name={name} claimInfo={metadata} cost={cost} costIncludesData={costIncludesData} />
+            <FormatsSection name={name} outpoint={outpoint} claimInfo={metadata} cost={cost} costIncludesData={costIncludesData} />
           ) : (
             <div>
               <h2>No content</h2>


### PR DESCRIPTION
- Refactoring throughout JSON-RPC, lbrynet and Lighthouse logic
- Move JSON-RPC stuff into its own module
- Add ability to directly call API methods on the lbry and lighthouse modules, e.g. `lbry.file_list({name: 'what'})`
- New-style API calls use promises instead of callbacks.
- Converted some lbrynet calls and all Lighthouse calls to use the new style

