### PR TITLE
Real update system

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -115,16 +115,19 @@ app.on('activate', () => {
 })
 
 
-function shutdownDaemon() {
+function shutdownDaemon(evenIfNotStartedByApp = false) {
   if (subpy) {
     console.log('Killing lbrynet-daemon process');
     kill(subpy.pid, undefined, (err) => {
       console.log('Killed lbrynet-daemon process');
     });
-  } else {
-    client.request('stop', []);
+  } else if (evenIfNotStartedByApp) {
+    console.log('Killing lbrynet-daemon, even though app did not start it');
+    client.request('daemon_stop', []);
     // TODO: If the daemon errors or times out when we make this request, find
     // the process and force quit it.
+  } else {
+    console.log('Not killing lbrynet-daemon because app did not start it')
   }
 
   // Is it safe to start the installer before the daemon finishes running?
@@ -132,13 +135,6 @@ function shutdownDaemon() {
 }
 
 function shutdown() {
-  /* if (!subpy) {
-    // TODO: In this case, we didn't start the process so I'm hesitant
-    //       to shut it down. We might want to send a stop command
-    //       though instead of just letting it run.
-    console.log('Not killing lbrynet daemon because we did not start it')
-    return
-  } */
   if (win) {
     win.loadURL(`file://${__dirname}/dist/quit.html`);
   }
@@ -148,15 +144,18 @@ function shutdown() {
 
 function upgrade(event, installerPath) {
   app.on('quit', () => {
-    console.log('installerPath is', installerPath);
     shell.openItem(installerPath);
-    console.log('after installerPath');
   });
   if (win) {
     win.loadURL(`file://${__dirname}/dist/upgrade.html`);
   }
   quitting = true;
-  shutdownDaemon();
+  shutdownDaemon(true);
+  // wait for daemon to shut down before upgrading
+  // what to do if no shutdown in a long time?
+  console.log('Update downloaded to ', installerPath);
+  console.log('The app will close, and you will be prompted to install the latest version of LBRY.');
+  console.log('After the install is complete, please reopen the app.');
 }
 
 ipcMain.on('upgrade', upgrade);

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -13,7 +13,7 @@ Web UI version numbers should always match the corresponding version of LBRY App
   * Wherever possible, use outpoints for unique IDs instead of names or SD hashes
 
 ### Changed
-  *
+  * Update process now easier and more reliable
   *
   *
 

--- a/ui/dist/upgrade.html
+++ b/ui/dist/upgrade.html
@@ -1,0 +1,37 @@
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width">
+    <title>LBRY</title>
+    
+    <link href='https://fonts.googleapis.com/css?family=Raleway:600,300' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400italic,600italic,600' rel='stylesheet' type='text/css'>
+    <link href="./css/all.css" rel="stylesheet" type="text/css" media="screen,print" />
+    <link href="./js/mediaelement/mediaelementplayer.css" rel="stylesheet" type="text/css" />
+    <link rel="icon" type="image/png" href="./img/fav/favicon-32x32.png" sizes="32x32">
+    <link rel="icon" type="image/png" href="./img/fav/favicon-194x194.png" sizes="194x194">
+    <link rel="icon" type="image/png" href="./img/fav/favicon-96x96.png" sizes="96x96">
+    <link rel="icon" type="image/png" href="./img/fav/android-chrome-192x192.png" sizes="192x192">
+    <link rel="icon" type="image/png" href="./img/fav/favicon-16x16.png" sizes="16x16">
+    
+    <meta name="msapplication-TileColor" content="#155B4A">
+    <meta name="msapplication-TileImage" content="/img/fav/mstile-144x144.png">
+    <meta name="theme-color" content="#155B4A">
+    <style>
+      body {
+        background-color: "#155b4a"
+      }
+</style>
+  </head>
+  <div id="canvas">
+    <div class="load-screen" style="color: white; min-height: 100vh; min-width: 100vw; display: flex; flex-direction: column; align-items: center; justify-content: center;">
+      <img src="./img/lbry-white-485x160.png" alt="LBRY">
+      <div style="margin-top: 24px; width: 325px; text-align: center;">
+	<h3>
+	  <span>Starting LBRY Upgrade <span class="busy-indicator"></span>
+	  </span>
+	</h3>
+      </div>
+    </div>
+  </div>
+</html>

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -110,10 +110,7 @@ var App = React.createClass({
         } else if (versionInfo.os_system == 'Linux') {
           var updateUrl = 'https://lbry.io/get/lbry.deb';
         } else if (versionInfo.os_system == 'Windows') {
-	  // A little weird, but for electron, the installer is
-	  // actually an exe. Maybe a better url would
-	  // be something like /get/windows ?
-          var updateUrl = 'https://lbry.io/get/lbry.msi';
+          var updateUrl = 'https://lbry.io/get/lbry.exe';
         } else {
           var updateUrl = 'https://lbry.io/get';
         }
@@ -299,13 +296,21 @@ var App = React.createClass({
 
           </Modal>
           <Modal isOpen={this.state.modal == 'downloading'} contentLabel="Downloading Update" type="custom">
-            Downloading Update{this.state.downloadProgress ? `: ${this.state.downloadProgress}% Complete` : null}
+            Downloading Update{this.state.downloadProgress ? `: ${this.state.downloadProgress}%` : null}
             <Line percent={this.state.downloadProgress} strokeWidth="4"/>
+            {this.state.downloadComplete ? (
+               <div>
+                 <br />
+                 <p>Click "Begin Upgrade" to start the upgrade process.</p>
+                 <p>The app will close, and you will be prompted to install the latest version of LBRY.</p>
+                 <p>After the install is complete, please reopen the app.</p>
+               </div>
+             ) : null }
             <div className="modal__buttons">
-             <Link button="alt" label="Cancel" className="modal__button" onClick={this.cancelUpgrade} />
-             {this.state.downloadComplete
+              {this.state.downloadComplete
                 ? <Link button="primary" label="Begin Upgrade" className="modal__button" onClick={this.handleStartUpgradeClicked} />
                 : null}
+              <Link button="alt" label="Cancel" className="modal__button" onClick={this.cancelUpgrade} />
             </div>
           </Modal>
           <ExpandableModal isOpen={this.state.modal == 'error'} contentLabel="Error" className="error-modal"

--- a/ui/js/component/modal.js
+++ b/ui/js/component/modal.js
@@ -33,10 +33,10 @@ export const Modal = React.createClass({
         {this.props.type == 'custom' // custom modals define their own buttons
           ? null
           : <div className="modal__buttons">
-              {this.props.type == 'confirm'
-                ? <Link button="alt" label={this.props.abortButtonLabel} className="modal__button" disabled={this.props.abortButtonDisabled} onClick={this.props.onAborted} />
-                : null}
-              <Link button="primary" label={this.props.confirmButtonLabel} className="modal__button" disabled={this.props.confirmButtonDisabled} onClick={this.props.onConfirmed} />
+             <Link button="primary" label={this.props.confirmButtonLabel} className="modal__button" disabled={this.props.confirmButtonDisabled} onClick={this.props.onConfirmed} />
+             {this.props.type == 'confirm'
+               ? <Link button="alt" label={this.props.abortButtonLabel} className="modal__button" disabled={this.props.abortButtonDisabled} onClick={this.props.onAborted} />
+               : null}
             </div>}
       </ReactModal>
     );

--- a/ui/js/page/developer.js
+++ b/ui/js/page/developer.js
@@ -48,7 +48,7 @@ const DeveloperPage = React.createClass({
       }
       catch (e) {}
       if (!upgradeSent) {
-        alert('Failed to start upgrade. Is "' + this.state.upgradePath.replace("C:\\fakepath\\", "") + '" a valid path to the upgrade?');
+        alert('Failed to start upgrade. Is "' + this.state.upgradePath + '" a valid path to the upgrade?');
       }
     }
   },


### PR DESCRIPTION
 - Now asks the daemon to close, even if it wasn't started by the same app
 - Improved UX during upgrade process (cancel buttons, final dialog where you approve the update, etc.)
 - Saves updates in temp directory, closes app and launches the installer

Todo (none of these are blocking merge):
 - Force kill the existing daemon if it doesn't stop
 - Improve visuals
 - Don't upgrade to RCs