### PR TITLE
Add context menu

### DIFF
--- a/app/menu/context-menu.js
+++ b/app/menu/context-menu.js
@@ -1,0 +1,36 @@
+const {Menu} = require('electron');
+const electron = require('electron');
+const app = electron.app;
+
+const contextMenuTemplate = [
+  {
+    role: 'cut',
+  },
+  {
+    role: 'copy',
+  },
+  {
+    role: 'paste',
+  },
+];
+
+module.exports = {
+  showContextMenu(win, posX, posY, showDevItems) {
+    let template = contextMenuTemplate.slice();
+    if (showDevItems) {
+      template.push({
+        type: 'separator',
+      });
+      template.push(
+        {
+          label: 'Inspect Element',
+          click() {
+            win.inspectElement(posX, posY);
+          }
+        }
+      );
+    }
+
+    Menu.buildFromTemplate(template).popup(win);
+  },
+};

--- a/ui/js/component/drawer.js
+++ b/ui/js/component/drawer.js
@@ -21,7 +21,7 @@ var drawerImageStyle = { //@TODO: remove this, img should be properly scaled onc
 
 var Drawer = React.createClass({
   handleLogoClicked: function(event) {
-    if (event.ctrlKey && event.shiftKey) {
+    if ((event.ctrlKey || event.metaKey) && event.shiftKey) {
       window.location.href = 'index.html?developer'
       event.preventDefault();
     }

--- a/ui/js/main.js
+++ b/ui/js/main.js
@@ -5,7 +5,16 @@ import lighthouse from './lighthouse.js';
 import App from './app.js';
 import SplashScreen from './component/splash.js';
 
+const {remote} = require('electron');
+const contextMenu = remote.require('./menu/context-menu');
+
 lbry.showMenuIfNeeded();
+
+window.addEventListener('contextmenu', (event) => {
+  contextMenu.showContextMenu(remote.getCurrentWindow(), event.x, event.y,
+                              lbry.getClientSetting('showDeveloperMenu'));
+  event.preventDefault();
+});
 
 var init = function() {
   window.lbry = lbry;


### PR DESCRIPTION
Has Cut, Copy, Paste, and when in developer mode there's also Inspect Element

Also adds Command-Shift-Click as an alternative shortcut to get to Developer Settings, now that Ctrl-Shift is used for context menu on Mac