### PR TITLE
Upgrade improvements and refactor shutdown process

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -93,10 +93,10 @@ function launchDaemonIfNotRunning() {
  * tries to force kill them.
  */
 function forceKillAllDaemons() {
-  console.log("Attempting to force kill any running lbrynet-daemon instances...");
+  console.log('Attempting to force kill any running lbrynet-daemon instances...');
 
   const fgrepOut = child_process.spawnSync('pgrep', ['-x', 'lbrynet-daemon'], {encoding: 'utf8'}).stdout;
-  const daemonPids = fgrepOut.split(/[^\d]+/).filter((pid) => pid);
+  const daemonPids = fgrepOut.match(/\d+/g);
   if (!daemonPids) {
     console.log('No lbrynet-daemon found running.');
   } else {

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -44,7 +44,6 @@ var App = React.createClass({
   _version: null,
 
   getUpdateUrl: function() {
-    console.log('os.platform is', os.platform());
     switch (os.platform()) {
       case 'darwin':
         return 'https://lbry.io/get/lbry.dmg';

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -49,7 +49,7 @@ var App = React.createClass({
       case 'linux':
         return 'https://lbry.io/get/lbry.deb';
       case 'win32':
-        return 'https://lbry.io/get/lbry.exe'; // should now be msi
+        return 'https://lbry.io/get/lbry.exe';
     }
   },
   // Hard code the filenames as a temporary workaroound, because

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -24,7 +24,6 @@ import {Link} from './component/link.js';
 
 const {remote, ipcRenderer, shell} = require('electron');
 const {download} = remote.require('electron-dl');
-const os = require('os');
 const path = require('path');
 const app = require('electron').remote.app;
 const fs = remote.require('fs');
@@ -44,7 +43,7 @@ var App = React.createClass({
   _version: null,
 
   getUpdateUrl: function() {
-    switch (os.platform()) {
+    switch (process.platform) {
       case 'darwin':
         return 'https://lbry.io/get/lbry.dmg';
       case 'linux':
@@ -53,14 +52,16 @@ var App = React.createClass({
         return 'https://lbry.io/get/lbry.exe'; // should now be msi
     }
   },
-  // Temporary workaround since electron-dl throws errors when you try to get the filename
+  // Hard code the filenames as a temporary workaroound, because
+  // electron-dl throws errors when you try to get the filename
   getUpgradeFilename: function() {
-    if (os.platform() == 'darwin') {
-      return `LBRY-${this._version}.dmg`;
-    } else if (os.platform() == 'linux') {
-      return `LBRY-${this._version}.deb`;
-    } else {
-      return `LBRY-${this._version}_amd64.deb`;
+    switch (process.platform) {
+      case 'darwin':
+        return `LBRY-${this._version}.dmg`;
+      case 'linux':
+        return `LBRY_${this._version}_amd64.deb`;
+      case 'windows':
+        return `LBRY.Setup.${this._version}.exe`;
     }
   },
   getInitialState: function() {

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -27,6 +27,7 @@ const {download} = remote.require('electron-dl');
 const os = require('os');
 const path = require('path');
 const app = require('electron').remote.app;
+const fs = remote.require('fs');
 
 
 var App = React.createClass({
@@ -137,16 +138,14 @@ var App = React.createClass({
     });
   },
   handleUpgradeClicked: function() {
-    // TODO: create a callback for onProgress and have the UI
-    //       show download progress
-    // TODO: calling lbry.stop() ends up displaying the "daemon
-    //       unexpectedly stopped" page. Have a better way of shutting down
-    let dir = app.getPath('temp');
+    // Make a new directory within temp directory so the filename is guaranteed to be available
+    const dir = fs.mkdtempSync(app.getPath('temp') + require('path').sep);
+
     let options = {
       onProgress: (p) => this.setState({downloadProgress: Math.round(p * 100)}),
       directory: dir,
     };
-    download(remote.getCurrentWindow(), this.state.updateUrl, options)
+    download(remote.getCurrentWindow(), this.getUpdateUrl(), options)
       .then(downloadItem => {
         /**
          * TODO: get the download path directly from the download object. It should just be


### PR DESCRIPTION
 - Manually call `xdg-open` instead of using `shell.openItem()`, which doesn't reliably work from the main process
 - If there's a connection error or timeout when asking the daemon to close, fall back on trying to force kill any copies of the daemon that are running

Outstanding issues before ready to merge:
 - Finish testing
 - Try on Windows (all of the known issues have to do with the logic of killing the daemon and restarting, so there shouldn't be anything huge that comes up here)
      - Will need to have Jack help get a dev install going on a Windows VM. Haven't done that since we switched to Electron
 - `xdg-open` doesn't work reliably if you're not the same user as the package manager. `shell.openItem()` would have the same problem as it ultimately just calls xdg-open. We should probably at least detect this scenario and do something different, e.g. reveal the file instead of open it, and display a notice that you'll have to click the file to start the upgrade.
    - This is an independent thing and isn't blocking merge.
