### PR TITLE
make page changes fast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Web UI version numbers should always match the corresponding version of LBRY App
 
 ## [Unreleased]
 ### Added
+  * The app is much more responsive switching pages. It no longer reloads the entire page and all assets on each page change.
+  * lbry.js now offers a subscription model for wallet balance similar to file info.
+  * Fixed file info subscribes not being unsubscribed in unmount.
+  * Fixed drawer not highlighting selected page.
   * You can now make API calls directly on the lbry module, e.g. lbry.peer_list()
   * New-style API calls return promises instead of using callbacks
   * Wherever possible, use outpoints for unique IDs instead of names or SD hashes

--- a/app/main.js
+++ b/app/main.js
@@ -17,7 +17,7 @@ let quitting = false;
 
 
 function createWindow () {
-  win = new BrowserWindow({backgroundColor: '#155b4a'})
+  win = new BrowserWindow({backgroundColor: '#155B4A'}) //$color-primary
   win.maximize()
   //win.webContents.openDevTools()
   win.loadURL(`file://${__dirname}/dist/index.html`)

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -60,8 +60,7 @@ var App = React.createClass({
   },
   getViewingPageAndArgs: function(address) {
     // For now, routes are in format ?page or ?page=args
-    let isMatch, viewingPage, pageArgs;
-    [isMatch, viewingPage, pageArgs] = address.match(/\??([^=]*)(?:=(.*))?/);
+    let [isMatch, viewingPage, pageArgs] = address.match(/\??([^=]*)(?:=(.*))?/);
     return {
       viewingPage: viewingPage,
       pageArgs: pageArgs === undefined ? null : pageArgs
@@ -87,7 +86,7 @@ var App = React.createClass({
     });
 
     //open links in external browser and skip full redraw on changing page
-    document.addEventListener('click', function(event) {
+    document.addEventListener('click', (event) => {
       var target = event.target;
       while (target && target !== document) {
         if (target.matches('a[href^="http"]')) {
@@ -103,7 +102,7 @@ var App = React.createClass({
         }
         target = target.parentNode;
       }
-    }.bind(this));
+    });
 
     lbry.checkNewVersionAvailable((isAvailable) => {
       if (!isAvailable || sessionStorage.getItem('upgradeSkipped')) {

--- a/ui/js/component/drawer.js
+++ b/ui/js/component/drawer.js
@@ -9,7 +9,7 @@ var DrawerItem = React.createClass({
     };
   },
   render: function() {
-    var isSelected = (this.props.viewingPage == this.props.href.substr(2) ||
+    var isSelected = (this.props.viewingPage == this.props.href.substr(1) ||
                       this.props.subPages.indexOf(this.props.viewingPage) != -1);
     return <Link {...this.props} className={ 'drawer-item ' + (isSelected ? 'drawer-item-selected' : '') } />
   }
@@ -20,9 +20,11 @@ var drawerImageStyle = { //@TODO: remove this, img should be properly scaled onc
 };
 
 var Drawer = React.createClass({
+  _balanceSubscribeId: null,
+
   handleLogoClicked: function(event) {
     if ((event.ctrlKey || event.metaKey) && event.shiftKey) {
-      window.location.href = 'index.html?developer'
+      window.location.href = '?developer'
       event.preventDefault();
     }
   },
@@ -32,25 +34,30 @@ var Drawer = React.createClass({
     };
   },
   componentDidMount: function() {
-    lbry.getBalance(function(balance) {
+    this._balanceSubscribeId = lbry.balanceSubscribe(function(balance) {
       this.setState({
         balance: balance
       });
     }.bind(this));
+  },
+  componentWillUnmount: function() {
+    if (this._balanceSubscribeId) {
+      lbry.balanceUnsubscribe(this._balanceSubscribeId)
+    }
   },
   render: function() {
     return (
       <nav id="drawer">
         <div id="drawer-handle">
           <Link title="Close" onClick={this.props.onCloseDrawer} icon="icon-bars" className="close-drawer-link"/>
-          <a href="index.html?discover" onMouseUp={this.handleLogoClicked}><img src={lbry.imagePath("lbry-dark-1600x528.png")} style={drawerImageStyle}/></a>
+          <a href="?discover" onMouseUp={this.handleLogoClicked}><img src={lbry.imagePath("lbry-dark-1600x528.png")} style={drawerImageStyle}/></a>
         </div>
-        <DrawerItem href='index.html?discover' viewingPage={this.props.viewingPage} label="Discover" icon="icon-search"  />
-        <DrawerItem href='index.html?publish' viewingPage={this.props.viewingPage} label="Publish" icon="icon-upload" />
-        <DrawerItem href='index.html?downloaded' subPages={['published']} viewingPage={this.props.viewingPage}  label="My Files" icon='icon-cloud-download' />
-        <DrawerItem href="index.html?wallet" subPages={['send', 'receive', 'claim', 'referral']} viewingPage={this.props.viewingPage}  label="My Wallet" badge={lbry.formatCredits(this.state.balance) } icon="icon-bank" />
-        <DrawerItem href='index.html?settings' viewingPage={this.props.viewingPage}  label="Settings" icon='icon-gear' />
-        <DrawerItem href='index.html?help' viewingPage={this.props.viewingPage}  label="Help" icon='icon-question-circle' />
+        <DrawerItem href='?discover' viewingPage={this.props.viewingPage} label="Discover" icon="icon-search"  />
+        <DrawerItem href='?publish' viewingPage={this.props.viewingPage} label="Publish" icon="icon-upload" />
+        <DrawerItem href='?downloaded' subPages={['published']} viewingPage={this.props.viewingPage}  label="My Files" icon='icon-cloud-download' />
+        <DrawerItem href="?wallet" subPages={['send', 'receive', 'claim', 'referral']} viewingPage={this.props.viewingPage}  label="My Wallet" badge={lbry.formatCredits(this.state.balance) } icon="icon-bank" />
+        <DrawerItem href='?settings' viewingPage={this.props.viewingPage}  label="Settings" icon='icon-gear' />
+        <DrawerItem href='?help' viewingPage={this.props.viewingPage}  label="Help" icon='icon-question-circle' />
       </nav>
     );
   }

--- a/ui/js/component/file-actions.js
+++ b/ui/js/component/file-actions.js
@@ -253,7 +253,7 @@ export let FileActions = React.createClass({
     if (this.isMounted) {
       this.setState({
         fileInfo: fileInfo,
-      });      
+      });
     }
   },
   componentDidMount: function() {
@@ -276,6 +276,9 @@ export let FileActions = React.createClass({
   },
   componentWillUnmount: function() {
     this._isMounted = false;
+    if (this._fileInfoSubscribeId) {
+      lbry.fileInfoUnsubscribe(this.props.outpoint, this._fileInfoSubscribeId);
+    }
   },
   render: function() {
     const fileInfo = this.state.fileInfo;

--- a/ui/js/component/file-tile.js
+++ b/ui/js/component/file-tile.js
@@ -79,7 +79,7 @@ export let FileTileStream = React.createClass({
   componentDidMount: function() {
     this._isMounted = true;
     if (this.props.hideOnRemove) {
-      lbry.fileInfoSubscribe(this.props.outpoint, this.onFileInfoUpdate);
+      this._fileInfoSubscribeId = lbry.fileInfoSubscribe(this.props.outpoint, this.onFileInfoUpdate);
     }
   },
   componentWillUnmount: function() {
@@ -121,15 +121,15 @@ export let FileTileStream = React.createClass({
       <section className={ 'file-tile card ' + (obscureNsfw ? 'card-obscured ' : '') } onMouseEnter={this.handleMouseOver} onMouseLeave={this.handleMouseOut}>
         <div className={"row-fluid card-content file-tile__row"}>
           <div className="span3">
-            <a href={'/?show=' + this.props.name}><Thumbnail className="file-tile__thumbnail" src={metadata.thumbnail} alt={'Photo for ' + (title || this.props.name)} /></a>
+            <a href={'?show=' + this.props.name}><Thumbnail className="file-tile__thumbnail" src={metadata.thumbnail} alt={'Photo for ' + (title || this.props.name)} /></a>
           </div>
           <div className="span9">
             { !this.props.hidePrice
               ? <FilePrice name={this.props.name} />
               : null}
-            <div className="meta"><a href={'index.html?show=' + this.props.name}>{'lbry://' + this.props.name}</a></div>
+            <div className="meta"><a href={'?show=' + this.props.name}>{'lbry://' + this.props.name}</a></div>
             <h3 className="file-tile__title">
-              <a href={'index.html?show=' + this.props.name}>
+              <a href={'?show=' + this.props.name}>
                 <TruncatedText lines={1}>
                   {title}
                 </TruncatedText>

--- a/ui/js/lbry.js
+++ b/ui/js/lbry.js
@@ -423,7 +423,7 @@ lbry._updateClaimOwnershipCache = function(claimId) {
 
 lbry._updateFileInfoSubscribers = function(outpoint) {
   const callSubscribedCallbacks = (outpoint, fileInfo) => {
-    for (let [subscribeId, callback] of Object.entries(this._fileInfoSubscribeCallbacks[outpoint])) {
+    for (let callback of Object.values(this._fileInfoSubscribeCallbacks[outpoint])) {
       callback(fileInfo);
     }
   }
@@ -471,7 +471,7 @@ lbry.fileInfoUnsubscribe = function(outpoint, subscribeId) {
 
 lbry._updateBalanceSubscribers = function() {
   lbry.get_balance().then(function(balance) {
-    for (let [subscribeId, callback] of Object.entries(lbry._balanceSubscribeCallbacks)) {
+    for (let callback of Object.values(lbry._balanceSubscribeCallbacks)) {
       callback(balance);
     }
   });

--- a/ui/js/page/file-list.js
+++ b/ui/js/page/file-list.js
@@ -41,7 +41,7 @@ export let FileListDownloaded = React.createClass({
     } else if (!this.state.fileInfos.length) {
       return (
         <main className="page">
-          <span>You haven't downloaded anything from LBRY yet. Go <Link href="/index.html?discover" label="search for your first download" />!</span>
+          <span>You haven't downloaded anything from LBRY yet. Go <Link href="?discover" label="search for your first download" />!</span>
         </main>
       );
     } else {
@@ -90,7 +90,7 @@ export let FileListPublished = React.createClass({
     else if (!this.state.fileInfos.length) {
       return (
         <main className="page">
-          <span>You haven't published anything to LBRY yet.</span> Try <Link href="index.html?publish" label="publishing" />!
+          <span>You haven't published anything to LBRY yet.</span> Try <Link href="?publish" label="publishing" />!
         </main>
       );
     }

--- a/ui/js/page/help.js
+++ b/ui/js/page/help.js
@@ -67,7 +67,7 @@ var HelpPage = React.createClass({
         <section className="card">
           <h3>Report a Bug</h3>
           <p>Did you find something wrong?</p>
-          <p><Link href="index.html?report" label="Submit a Bug Report" icon="icon-bug" button="alt" /></p>
+          <p><Link href="?report" label="Submit a Bug Report" icon="icon-bug" button="alt" /></p>
           <div className="meta">Thanks! LBRY is made by its users.</div>
         </section>
         {!ver ? null :

--- a/ui/js/page/show.js
+++ b/ui/js/page/show.js
@@ -155,7 +155,7 @@ var DetailPage = React.createClass({
           ) : (
             <div>
               <h2>No content</h2>
-              There is no content available at the name <strong>lbry://{this.props.name}</strong>. If you reached this page from a link within the LBRY interface, please <Link href="index.html?report" label="report a bug" />. Thanks!
+              There is no content available at the name <strong>lbry://{this.props.name}</strong>. If you reached this page from a link within the LBRY interface, please <Link href="?report" label="report a bug" />. Thanks!
             </div>
           )}
         </section>

--- a/ui/js/page/wallet.js
+++ b/ui/js/page/wallet.js
@@ -243,6 +243,8 @@ var TransactionList = React.createClass({
 
 
 var WalletPage = React.createClass({
+  _balanceSubscribeId: null,
+
   propTypes: {
     viewingPage: React.PropTypes.string,
   },
@@ -259,11 +261,16 @@ var WalletPage = React.createClass({
     }
   },
   componentWillMount: function() {
-    lbry.getBalance((results) => {
+    this._balanceSubscribeId = lbry.balanceSubscribe((results) => {
       this.setState({
         balance: results,
       })
     });
+  },
+  componentWillUnmount: function() {
+    if (this._balanceSubscribeId) {
+      lbry.balanceUnsubscribe(this._balanceSubscribeId);
+    }
   },
   render: function() {
     return (

--- a/ui/scss/component/_load-screen.scss
+++ b/ui/scss/component/_load-screen.scss
@@ -2,6 +2,7 @@
 
 .load-screen {
   color: white;
+  background: $color-primary;
   background-size: cover;
   min-height: 100vh;
   min-width: 100vw;


### PR DESCRIPTION
This started as simply wanting to catch click events and re-draw the app inside of app.js without a full reload of index.html and all assets. However, it turned out to require adding a subscription feature for balances and fixing a few other areas where we were not unsubscribing/unmounting properly.