### PR TITLE
Removed .bind() from lambda

### DIFF
--- a/ui/js/page/wallet.js
+++ b/ui/js/page/wallet.js
@@ -16,7 +16,7 @@ var AddressSection = React.createClass({
       this.setState({
         address: address,
       });
-    }.bind(this));
+    });
   },
 
   _getNewAddress: function(event) {
@@ -29,7 +29,7 @@ var AddressSection = React.createClass({
       this.setState({
         address: address,
       });
-    }.bind(this));
+    });
   },
 
   getInitialState: function() {


### PR DESCRIPTION
wallet.js did not compile with .bind after the lambda function, and after talking in #dev in Gitter we came to the conclusion to just remove the bind as it's not necessary