### PR TITLE
Make error modals display full screen properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Web UI version numbers should always match the corresponding version of LBRY App
   *
 
 ### Fixed
-  *
+  * Error modals now display full screen properly
   *
 
 ### Deprecated

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -303,7 +303,7 @@ var App = React.createClass({
             </div>
           </Modal>
           <ExpandableModal isOpen={this.state.modal == 'error'} contentLabel="Error" className="error-modal"
-                           overlayClassName="error-modal-overlay" onConfirmed={this.closeModal}
+                           overlayClassName="modal-overlay error-modal-overlay" onConfirmed={this.closeModal}
                            extraContent={this.state.errorInfo}>
             <h3 className="modal__header">Error</h3>
 

--- a/ui/js/component/modal.js
+++ b/ui/js/component/modal.js
@@ -28,7 +28,7 @@ export const Modal = React.createClass({
     return (
       <ReactModal onCloseRequested={this.props.onAborted || this.props.onConfirmed} {...this.props}
                   className={(this.props.className || '') + ' modal'}
-                  overlayClassName={[null, undefined, ""].indexOf(this.props.overlayClassName) === -1 ? this.props.overlayClassName : 'modal-overlay'}>
+                  overlayClassName={![null, undefined, ""].includes(this.props.overlayClassName) ? this.props.overlayClassName : 'modal-overlay'}>
         <div>
           {this.props.children}
         </div>


### PR DESCRIPTION
Was not passing in the generic modal-overlay class. (ExpandableModal doesn't provide it automatically so you can omit it and make a totally custom overlay if you want.)