### PR TITLE
Don't try to send version info to render process if window isn't open

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -52,19 +52,25 @@ function checkForNewVersion(callback) {
       const [_, remoteVersion] = tagName.match(/^v([\d.]+(?:-?rc\d+)?)$/);
       if (!remoteVersion) {
         console.log('Malformed remote version string:', tagName);
-        win.webContents.send('version-info-received', null);
+        if (win) {
+          win.webContents.send('version-info-received', null);
+        }
       } else {
         console.log('Remote version:', remoteVersion);
         const upgradeAvailable = semver.gt(formatRc(remoteVersion), formatRc(localVersion));
         console.log(upgradeAvailable ? 'Upgrade available' : 'No upgrade available');
-        win.webContents.send('version-info-received', {remoteVersion, localVersion, upgradeAvailable});
+        if (win) {
+          win.webContents.send('version-info-received', {remoteVersion, localVersion, upgradeAvailable});          
+        }
       }
     })
   });
 
   req.on('error', (err) => {
     console.log('Failed to get current version from GitHub. Error:', err);
-    win.webContents.send('version-info-received', null);
+    if (win) {
+      win.webContents.send('version-info-received', null);      
+    }
   });
 }
 


### PR DESCRIPTION
In #30 we're still getting some reports of an error box after LBRY is closed. I suspect that's just because some people are running 0.9.x and the problem went away in 0.10.0. But this bug could cause a similar looking error in certain edge cases (user closes window before upgrade check finishes, or the upgrade connection gets stuck open somehow and only ends when LBRY is closing).