### PR TITLE
URI handling (WIP)

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -303,3 +303,12 @@ function upgrade(event, installerPath) {
 }
 
 ipcMain.on('upgrade', upgrade);
+
+if (process.platform == 'darwin') {
+  app.on('open-url', (event, uri) => {
+    win.webContents.send('open-uri-requested', url);
+  });
+} else if (process.argv.length >= 3) {
+  // No open-url event on Win, but we can still handle URIs provided at launch time
+  win.webContents.send('open-uri-requested', process.argv[2]);
+}

--- a/app/main.js
+++ b/app/main.js
@@ -306,7 +306,7 @@ ipcMain.on('upgrade', upgrade);
 
 if (process.platform == 'darwin') {
   app.on('open-url', (event, uri) => {
-    win.webContents.send('open-uri-requested', url);
+    win.webContents.send('open-uri-requested', uri);
   });
 } else if (process.argv.length >= 3) {
   // No open-url event on Win, but we can still handle URIs provided at launch time

--- a/app/main.js
+++ b/app/main.js
@@ -114,11 +114,12 @@ function getPidsForProcessName(name) {
 
 function createWindow () {
   win = new BrowserWindow({backgroundColor: '#155B4A', minWidth: 800, minHeight: 600 }) //$color-primary
+
   win.maximize()
   // win.webContents.openDevTools();
   win.loadURL(`file://${__dirname}/dist/index.html`)
   if (openUri) { // We stored and received a URI that an external app requested before we had a window object
-    win.on('did-finish-load', () => {
+    win.webContents.on('did-finish-load', () => {
       win.webContents.send('open-uri-requested', openUri);
     });
   }

--- a/package.json
+++ b/package.json
@@ -32,11 +32,19 @@
       },
       "backgroundColor": "155B4A"
     },
+    "protocols": [{
+      "name": "lbry",
+      "role": "Viewer",
+      "schemes": ["lbry"]
+    }],
     "linux": {
       "target": "deb"
     },
     "win": {
       "target": "nsis"
+    },
+    "nsis": {
+      "perMachine": true
     }
   },
   "devDependencies": {

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -95,6 +95,10 @@ var App = React.createClass({
       this.alertError(event.detail);
     });
 
+    ipcRenderer.on('open-uri-requested', (event, uri) => {
+      this.openUri(uri);
+    });
+
     //open links in external browser and skip full redraw on changing page
     document.addEventListener('click', (event) => {
       var target = event.target;
@@ -152,7 +156,7 @@ var App = React.createClass({
       pageArgs: term
     });
   },
-  onSubmit: function(uri) {
+  openUri: function(uri) {
     this._storeHistoryOfNextRender = true;
     this.setState({
       address: uri,
@@ -275,7 +279,7 @@ var App = React.createClass({
       this._fullScreenPages.includes(this.state.viewingPage) ?
         mainContent :
         <div id="window">
-          <Header onSearch={this.onSearch} onSubmit={this.onSubmit} address={address} wunderBarIcon={wunderBarIcon} viewingPage={this.state.viewingPage} />
+          <Header onSearch={this.onSearch} onSubmit={this.openUri} address={address} wunderBarIcon={wunderBarIcon} viewingPage={this.state.viewingPage} />
           <div id="main-content">
             {mainContent}
           </div>

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -88,7 +88,12 @@ var App = React.createClass({
       downloadComplete: false,
     });
   },
+
   componentWillMount: function() {
+    if ('openUri' in this.props) { // A URI was requested by an external app
+      this.showUri(this.props.openUri);
+    }
+
     window.addEventListener("popstate", this.onHistoryPop);
 
     document.addEventListener('unhandledError', (event) => {
@@ -96,7 +101,7 @@ var App = React.createClass({
     });
 
     ipcRenderer.on('open-uri-requested', (event, uri) => {
-      this.openUri(uri);
+      this.showUri(uri);
     });
 
     //open links in external browser and skip full redraw on changing page
@@ -140,6 +145,11 @@ var App = React.createClass({
   componentDidMount: function() {
     this._isMounted = true;
   },
+  componentWillReceiveProps: function(nextProps) {
+    if ('openUri' in nextProps && (!('openUri' in this.props) || nextProps.openUri != this.props.openUri)) {
+      this.showUri(nextProps.openUri);
+    }
+  },
   componentWillUnmount: function() {
     this._isMounted = false;
     window.removeEventListener("popstate", this.onHistoryPop);
@@ -156,13 +166,13 @@ var App = React.createClass({
       pageArgs: term
     });
   },
-  openUri: function(uri) {
+  showUri: function(uri) {
     this._storeHistoryOfNextRender = true;
     this.setState({
       address: uri,
       appUrl: "?show=" + encodeURIComponent(uri),
       viewingPage: "show",
-      pageArgs: uri
+      pageArgs: uri,
     })
   },
   handleUpgradeClicked: function() {
@@ -279,7 +289,7 @@ var App = React.createClass({
       this._fullScreenPages.includes(this.state.viewingPage) ?
         mainContent :
         <div id="window">
-          <Header onSearch={this.onSearch} onSubmit={this.openUri} address={address} wunderBarIcon={wunderBarIcon} viewingPage={this.state.viewingPage} />
+          <Header onSearch={this.onSearch} onSubmit={this.showUri} address={address} wunderBarIcon={wunderBarIcon} viewingPage={this.state.viewingPage} />
           <div id="main-content">
             {mainContent}
           </div>

--- a/ui/js/main.js
+++ b/ui/js/main.js
@@ -19,10 +19,6 @@ window.addEventListener('contextmenu', (event) => {
   event.preventDefault();
 });
 
-ipcRenderer.on('open-uri-requested', (event, uri) => {
-  window.location.href = `?show=${uri}`;
-});
-
 let init = function() {
   window.lbry = lbry;
   window.lighthouse = lighthouse;

--- a/ui/js/main.js
+++ b/ui/js/main.js
@@ -19,6 +19,18 @@ window.addEventListener('contextmenu', (event) => {
   event.preventDefault();
 });
 
+let openUri = null;
+
+function onOpenUriRequested(event, uri) {
+  /**
+   * If an external app requests a URI while we're still on the splash screen, we store it to
+   * later pass into the App component.
+   */
+   openUri = uri;
+};
+ipcRenderer.on('open-uri-requested', onOpenUriRequested);
+
+
 let init = function() {
   window.lbry = lbry;
   window.lighthouse = lighthouse;
@@ -30,7 +42,8 @@ let init = function() {
 
   function onDaemonReady() {
     window.sessionStorage.setItem('loaded', 'y'); //once we've made it here once per session, we don't need to show splash again
-    ReactDOM.render(<div>{ lbryio.enabled ? <AuthOverlay/> : '' }<App /><SnackBar /></div>, canvas)
+    ipcRenderer.removeListener('open-uri-requested', onOpenUriRequested); // <App /> will handle listening for URI requests once it's loaded
+    ReactDOM.render(<div>{ lbryio.enabled ? <AuthOverlay/> : '' }<App {... openUri ? {openUri: openUri} : {}} /><SnackBar /></div>, canvas)
   }
 
   if (window.sessionStorage.getItem('loaded') == 'y') {

--- a/ui/js/main.js
+++ b/ui/js/main.js
@@ -8,7 +8,7 @@ import SplashScreen from './component/splash.js';
 import SnackBar from './component/snack-bar.js';
 import {AuthOverlay} from './component/auth.js';
 
-const {remote} = require('electron');
+const {remote, ipcRenderer} = require('electron');
 const contextMenu = remote.require('./menu/context-menu');
 
 lbry.showMenuIfNeeded();
@@ -17,6 +17,10 @@ window.addEventListener('contextmenu', (event) => {
   contextMenu.showContextMenu(remote.getCurrentWindow(), event.x, event.y,
                               lbry.getClientSetting('showDeveloperMenu'));
   event.preventDefault();
+});
+
+ipcRenderer.on('open-uri-requested', (event, uri) => {
+  window.location.href = `?show=${uri}`;
 });
 
 let init = function() {


### PR DESCRIPTION
Implements opening LBRY URIs using Electron's built-in support.

Electron only has very basic support for this: on Mac it works well, but on Windows it can only pass the URI in as a command line argument (i.e. you can't launch URIs in an app that's already running), and there's no Linux support at all yet.

I'm thinking we'd be best off to use the built-in functionality like this, and then eventually hack on improvements for Win and Linux. [Here are some ideas](https://github.com/electron/electron/issues/4857#issuecomment-201124281) about how to do it in Linux.