### PR TITLE
Make FileTile resolve URIs (fixes exact search matching)

### DIFF
--- a/ui/js/actions/content.js
+++ b/ui/js/actions/content.js
@@ -146,12 +146,6 @@ export function doFetchFeaturedUris() {
           uris: featuredUris,
         }
       })
-
-      Object.keys(Uris).forEach((category) => {
-        Uris[category].forEach((uri) => {
-          dispatch(doResolveUri(lbryuri.normalize(uri)))
-        })
-      })
     }
 
     const failure = () => {

--- a/ui/js/component/fileTile/index.js
+++ b/ui/js/component/fileTile/index.js
@@ -8,20 +8,30 @@ import {
 import {
   makeSelectFileInfoForUri,
 } from 'selectors/file_info'
+import {
+  makeSelectResolvingUri,
+} from 'selectors/content'
+import {
+  doResolveUri,
+} from 'actions/content'
 import FileTile from './view'
 
 const makeSelect = () => {
   const selectClaimForUri = makeSelectClaimForUri()
   const selectFileInfoForUri = makeSelectFileInfoForUri()
+  const selectResolvingUri = makeSelectResolvingUri()
+
   const select = (state, props) => ({
     claim: selectClaimForUri(state, props),
     fileInfo: selectFileInfoForUri(state, props),
+    resolvingUri: selectResolvingUri(state, props),
   })
 
   return select
 }
 
 const perform = (dispatch) => ({
+  resolveUri: (uri) => dispatch(doResolveUri(uri)),
 })
 
 export default connect(makeSelect, perform)(FileTile)

--- a/ui/js/component/fileTile/view.jsx
+++ b/ui/js/component/fileTile/view.jsx
@@ -7,24 +7,31 @@ import FileTileStream from 'component/fileTileStream'
 import FileActions from 'component/fileActions';
 
 class FileTile extends React.Component {
+  componentDidMount() {
+    const {
+      resolvingUri,
+      resolveUri,
+      claim,
+      uri,
+    } = this.props
+
+    if(!resolvingUri && !claim) {
+      resolveUri(uri)
+    }
+  }
+
   render() {
     const {
       displayStyle,
       uri,
       claim,
+      resolvingUri,
+      resolveUri,
     } = this.props
 
-    if(!claim) {
-      if (displayStyle == 'card') {
-        return <FileCardStream uri={uri} />
-      }
-      return null
-    }
+    if (displayStyle == 'card') return <FileCardStream uri={uri} />
 
-    return displayStyle == 'card' ?
-      <FileCardStream uri={uri} />
-      :
-      <FileTileStream uri={uri} key={uri} />  
+    return <FileTileStream uri={uri} />
   }
 }
 

--- a/ui/js/component/fileTileStream/view.jsx
+++ b/ui/js/component/fileTileStream/view.jsx
@@ -83,81 +83,39 @@ class FileTileStream extends React.Component {
     }
 
     return (
-      <section className={ 'card card--small card--link ' + (obscureNsfw ? 'card--obscured ' : '') } onMouseEnter={this.handleMouseOver.bind(this)} onMouseLeave={this.handleMouseOut.bind(this)}>
-        <div className="card__inner">
-          <Link onClick={() => navigate('/show', { uri })} className="card__link">
-            <div className="card__title-identity">
-              <h5 title={title}><TruncatedText lines={1}>{title}</TruncatedText></h5>
-              <div className="card__subtitle">
-                { !this.props.hidePrice ? <span style={{float: "right"}}><FilePrice uri={uri} /></span>  : null}
-                <UriIndicator uri={uri} />
-              </div>
+      <section className={ 'file-tile card ' + (obscureNsfw ? 'card--obscured ' : '') } onMouseEnter={this.handleMouseOver.bind(this)} onMouseLeave={this.handleMouseOut.bind(this)}>
+        <Link onClick={() => navigate('/show', { uri })} className="card__link" className="card__link">
+          <div className={"card__inner file-tile__row"}>
+            <div className="card__media"
+                 style={{ backgroundImage: "url('" + (metadata && metadata.thumbnail ? metadata.thumbnail : lbry.imagePath('default-thumb.svg')) + "')" }}>
             </div>
-            { metadata && metadata.thumbnail ?
-              <div className="card__media" style={{ backgroundImage: "url('" + metadata.thumbnail + "')" }}></div> :
-              <div className="card__media" style={{ backgroundImage: "url('" + lbry.imagePath('default-thumb.svg') + "')" }}></div>
-            }
-            <div className="card__content card__subtext card__subtext--two-lines">
-                <TruncatedText lines={2}>
+            <div className="file-tile__content">
+              <div className="card__title-primary">
+                { !this.props.hidePrice
+                  ? <FilePrice uri={this.props.uri} />
+                  : null}
+                <div className="meta">{uri}</div>
+                <h3><TruncatedText lines={1}>{title}</TruncatedText></h3>
+              </div>
+              <div className="card__content card__subtext">
+                <TruncatedText lines={3}>
                   {isConfirmed
                     ? metadata.description
                     : <span className="empty">This file is pending confirmation.</span>}
                 </TruncatedText>
+              </div>
             </div>
-          </Link>
-          {this.state.showNsfwHelp && this.state.hovered
-            ? <div className='card-overlay'>
-             <p>
-               This content is Not Safe For Work.
-               To view adult content, please change your <Link className="button-text" onClick={() => navigate('/settings')} label="Settings" />.
-             </p>
-           </div>
-            : null}
-        </div>
+          </div>
+        </Link>
+        {this.state.showNsfwHelp
+          ? <div className='card-overlay'>
+           <p>
+              This content is Not Safe For Work.
+              To view adult content, please change your <Link className="button-text" onClick={() => navigate('/settings')} label="Settings" />.
+           </p>
+         </div>
+          : null}
       </section>
-      // <section className={ 'file-tile card ' + (obscureNsfw ? 'card--obscured ' : '') } onMouseEnter={this.handleMouseOver.bind(this)} onMouseLeave={this.handleMouseOut.bind(this)}>
-      //   <div className={"row-fluid card__inner file-tile__row"}>
-      //     <div className="span3 file-tile__thumbnail-container">
-      //       <Link onClick={() => navigate('/show', { uri })}>
-      //         {metadata && metadata.thumbnail ?
-      //         <Thumbnail key={this.props.uri} className="file-tile__thumbnail" src={metadata.thumbnail} alt={'Photo for ' + this.props.uri} />
-      //         :
-      //         <Thumbnail className="file-tile__thumbnail" alt={'Photo for ' + this.props.uri} />
-      //         }
-      //       </Link>
-      //     </div>
-      //     <div className="span9">
-      //       <div className="card__title-primary">
-      //         { !this.props.hidePrice
-      //           ? <FilePrice uri={this.props.uri} />
-      //           : null}
-      //           <div className="meta"><Link onClick={() => navigate('/show', { uri })}>{uri}</Link></div>
-      //         <h3>
-      //           <Link onClick={() => navigate('/show', { uri })} title={title}>
-      //             <TruncatedText lines={1}>
-      //               {title}
-      //             </TruncatedText>
-      //           </Link>
-      //         </h3>
-      //       </div>
-      //       <div className="card__actions">
-      //       </div>
-      //       <div className="card__content">
-      //         <p className="file-tile__description">
-      //           <TruncatedText lines={2}>{description}</TruncatedText>
-      //         </p>
-      //       </div>
-      //     </div>
-      //   </div>
-      //   {this.state.showNsfwHelp
-      //     ? <div className='card-overlay'>
-      //      <p>
-      //        This content is Not Safe For Work.
-      //        To view adult content, please change your <Link className="button-text" onClick={() => navigate('/settings')} label="Settings" />.
-      //      </p>
-      //    </div>
-      //     : null}
-      // </section>
     );
   }
 }

--- a/ui/js/page/search/view.jsx
+++ b/ui/js/page/search/view.jsx
@@ -77,7 +77,7 @@ const SearchPage = (props) => {
             Exact URL
             <ToolTip label="?" body="This is the resolution of a LBRY URL and not controlled by LBRY Inc." className="tooltip--header" />
           </h3>
-          <FileTile uri={query} showEmpty={true} />
+          <FileTile uri={lbryuri.normalize(query)} showEmpty={true} />
         </section> : '' }
       <section className="section-spaced">
         <h3 className="card-row__header">


### PR DESCRIPTION
Fixes exact search matching and search results HTML @kauffj.

I have no idea why default thumbnails aren't resolving any more or when that stopped working :(

I think in order for this to be mergable to master we need to:

- fix default thumbnails
- store file info in the state by `sd_hash` rather than URI and then fix the downloaded/published pages (right now published appear in downloaded after you loaded both and it starts throwing errors)
- do a test run to make sure rewards is still working

We'd need to then lookup files by first selecting the claim for a URI, then running a selector that iterates all files in the state and grabs the one with the matching outpoint. It seems to make sense to store files by `sd_hash` though, as claim and outpoint can sometimes be `null`, in the case of files that are being uploaded or failed to upload for example.