### PR TITLE
Linux URI handling (WIP)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,11 @@
       "schemes": ["lbry"]
     }],
     "linux": {
-      "target": "deb"
+      "target": "deb",
+      "desktop": {
+        "MimeType": "x-scheme-handler/lbry",
+        "Exec": "/opt/LBRY/lbry %U"
+      }
     },
     "win": {
       "target": "nsis"


### PR DESCRIPTION
Still left to do: get single-instance app mode working on Linux.

In theory, it should work the same as Windows without any changes. The problem is that `app.makeSingleInstance()` is always returning true on Linux, meaning "this is the not the original process and the app should close." Probably an Electron bug, but there might be a workaround, and the worst case is that we implement a similar system from scratch.