### PR TITLE
Convert file fields to use native Electron dialog + add directory selector field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,8 @@ Web UI version numbers should always match the corresponding version of LBRY App
   * Enable windows code signing of binary
 
 ### Changed
-  *
-  *
+  * Use directory selector instead of ugly text box on Settings page
+  * Use Electron's native file selector everywhere instead of WebKit file selector
 
 ### Fixed
   * Error modals now display full screen properly

--- a/ui/js/component/file-selector.js
+++ b/ui/js/component/file-selector.js
@@ -1,0 +1,58 @@
+import React from 'react';
+
+const {remote} = require('electron');
+class FileSelector extends React.Component {
+  static propTypes = {
+    type: React.PropTypes.oneOf(['file', 'directory']),
+    initPath: React.PropTypes.string,
+    onFileChosen: React.PropTypes.func,
+  }
+
+  static defaultProps = {
+    type: 'file',
+  }
+
+  componentWillMount() {
+    this.setState({
+      path: this.props.initPath || null,
+    });
+  }
+
+  handleButtonClick() {
+    remote.dialog.showOpenDialog({
+      properties: [this.props.type == 'file' ? 'openFile' : 'openDirectory'],
+    }, (paths) => {
+      if (!paths) { // User hit cancel, so do nothing
+        return;
+      }
+
+      const path = paths[0];
+      this.setState({
+        path: path,
+      });
+      if (this.props.onFileChosen) {
+        this.props.onFileChosen(path);
+      }
+    });
+  }
+
+  render() {
+    return (
+      <div className="file-selector">
+        <button type="button" className="file-selector__choose-button" onClick={() => this.handleButtonClick()}>
+          {this.props.type == 'file' ?
+              'Choose File' :
+              'Choose Directory'}
+        </button>
+        {' '}
+        <span className="file-selector__path">
+          {this.state.path ?
+             this.state.path :
+             'No File Chosen'}
+        </span>
+      </div>
+    );
+  }
+};
+
+export default FileSelector;

--- a/ui/js/page/developer.js
+++ b/ui/js/page/developer.js
@@ -30,7 +30,7 @@ const DeveloperPage = React.createClass({
   },
   handleUpgradeFileChange: function(event) {
     this.setState({
-      upgradePath: event.target.files[0].path,
+      upgradePath: event.target.value,
     });
   },
   handleForceUpgradeClick: function() {

--- a/ui/js/page/settings.js
+++ b/ui/js/page/settings.js
@@ -97,11 +97,11 @@ var SettingsPage = React.createClass({
             <h3>Download Directory</h3>
           </div>
           <div className="card__content">
-            <FormRow type="text"
-                   name="download_directory"
-                   defaultValue={this.state.daemonSettings.download_directory}
-                   helper="LBRY downloads will be saved here."
-                   onChange={this.onDownloadDirChange} />
+            <FormRow type="directory"
+                     name="download_directory"
+                     defaultValue={this.state.daemonSettings.download_directory}
+                     helper="LBRY downloads will be saved here."
+                     onChange={this.onDownloadDirChange} />
           </div>
         </section>
         <section className="card">

--- a/ui/scss/all.scss
+++ b/ui/scss/all.scss
@@ -6,6 +6,7 @@
 @import "component/_button.scss";
 @import "component/_card.scss";
 @import "component/_file-actions.scss";
+@import "component/_file-selector.scss";
 @import "component/_file-tile.scss";
 @import "component/_form-field.scss";
 @import "component/_header.scss";

--- a/ui/scss/component/_file-selector.scss
+++ b/ui/scss/component/_file-selector.scss
@@ -1,0 +1,7 @@
+.file-selector__choose-button {
+  font-size: 13px;
+}
+
+.file-selector__path {
+  font-size: 14px;
+}


### PR DESCRIPTION
This will make it much easier to customize look and feel, and allows extra features like pre-populating with an existing file. This also updates the Settings page to use the new directory selector.