### PR TITLE
set ENV to production webpack.config.js

### DIFF
--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -21,7 +21,7 @@ module.exports = {
   },
   plugins: [
     new webpack.DefinePlugin({
-      ENV: JSON.stringify("development"),
+      ENV: JSON.stringify("production"),
     }),
   ],
   module: {


### PR DESCRIPTION
So we don't have redux logs in releases.