### PR TITLE
Fix naming:  Publishes > Published for address bar

### DIFF
--- a/ui/js/selectors/app.js
+++ b/ui/js/selectors/app.js
@@ -56,7 +56,7 @@ export const selectPageTitle = createSelector(
       case 'downloaded':
         return 'Downloads & Purchases'
       case 'published':
-        return 'Publishes'
+        return 'Published'
       case 'start':
         return 'Start'
       case 'publish':


### PR DESCRIPTION
When going to Published files, the address bar would show "Publishes". Changed this to "Published".