### PR TITLE
Upgrades fixes

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -116,7 +116,7 @@ function openItem(fullPath) {
     } else if (process.platform == 'linux') {
       child = child_process.spawn('xdg-open', [fullPath], subprocOptions);
     } else if (process.platform == 'win32') {
-      child = child_process.spawn(fullPath, [], subprocOptions);
+      child = child_process.spawn(fullPath, Object.assign({}, subprocOptions, {shell: true}));
     }
 
     // Causes child process reference to be garbage collected, allowing main process to exit

--- a/ui/js/actions/app.js
+++ b/ui/js/actions/app.js
@@ -2,7 +2,7 @@ import * as types from 'constants/action_types'
 import lbry from 'lbry'
 import {
   selectUpdateUrl,
-  selectUpgradeDownloadDir,
+  selectUpgradeDownloadPath,
   selectUpgradeDownloadItem,
   selectUpgradeFilename,
   selectPageTitle,
@@ -110,7 +110,7 @@ export function doSkipUpgrade() {
 export function doStartUpgrade() {
   return function(dispatch, getState) {
     const state = getState()
-    const upgradeDownloadPath = selectUpgradeDownloadDir(state)
+    const upgradeDownloadPath = selectUpgradeDownloadPath(state)
 
     ipcRenderer.send('upgrade', upgradeDownloadPath)
   }
@@ -135,14 +135,11 @@ export function doDownloadUpgrade() {
          * too soon.
          */
 
-        const _upgradeDownloadItem = downloadItem;
-        const _upgradeDownloadPath = path.join(dir, upgradeFilename);
-
         dispatch({
           type: types.UPGRADE_DOWNLOAD_COMPLETED,
           data: {
-            dir,
-            downloadItem
+            downloadItem,
+            path: path.join(dir, upgradeFilename)
           }
         })
       });

--- a/ui/js/reducers/app.js
+++ b/ui/js/reducers/app.js
@@ -34,7 +34,7 @@ reducers[types.UPGRADE_CANCELLED] = function(state, action) {
 
 reducers[types.UPGRADE_DOWNLOAD_COMPLETED] = function(state, action) {
   return Object.assign({}, state, {
-    downloadDir: action.data.dir,
+    downloadPath: action.data.path,
     upgradeDownloading: false,
     upgradeDownloadCompleted: true
   })

--- a/ui/js/selectors/app.js
+++ b/ui/js/selectors/app.js
@@ -170,9 +170,9 @@ export const selectUpgradeSkipped = createSelector(
   (state) => state.upgradeSkipped
 )
 
-export const selectUpgradeDownloadDir = createSelector(
+export const selectUpgradeDownloadPath = createSelector(
   _selectState,
-  (state) => state.downloadDir
+  (state) => state.downloadPath
 )
 
 export const selectUpgradeDownloadItem = createSelector(

--- a/ui/js/selectors/app.js
+++ b/ui/js/selectors/app.js
@@ -107,11 +107,11 @@ export const selectUpgradeFilename = createSelector(
   (platform, version) => {
     switch (platform) {
       case 'darwin':
-        return `LBRY-${version}.dmg`;
+        return `LBRY_${version}.dmg`;
       case 'linux':
         return `LBRY_${version}_amd64.deb`;
       case 'win32':
-        return `LBRY.Setup.${version}.exe`;
+        return `LBRY_${version}.exe`;
       default:
         throw 'Unknown platform';
     }


### PR DESCRIPTION
Fixes several recent problems with upgrades:
 - After the Redux refactor, we ended up opening the directory instead of the file
 - The file names changed on Windows and Mac but the source code wasn't updated (we didn't catch it because we were just opening the folder anyway)
 - On Windows, we weren't spawning the installer inside a shell, so it couldn't show the "this app wants elevated permissions" box and the `child_process.spawn()` call was silently throwing an error. Beats me why it worked before.