### PR TITLE
Play more file types

### DIFF
--- a/ui/js/actions/app.js
+++ b/ui/js/actions/app.js
@@ -52,6 +52,7 @@ export function doChangePath(path) {
     const state = getState()
     const pageTitle = selectPageTitle(state)
     window.document.title = pageTitle
+    window.scrollTo(0, 0)
 
     const currentPage = selectCurrentPage(state)
     if (currentPage === 'search') {

--- a/ui/js/actions/content.js
+++ b/ui/js/actions/content.js
@@ -166,6 +166,8 @@ export function doDownloadFile(uri, streamInfo) {
           fileInfo,
         }
       })
+
+      dispatch(doUpdateLoadStatus(uri, streamInfo.outpoint))
     })
 
     lbryio.call('file', 'view', {
@@ -176,7 +178,6 @@ export function doDownloadFile(uri, streamInfo) {
 
     rewards.claimEligiblePurchaseRewards()
 
-    dispatch(doUpdateLoadStatus(uri, streamInfo.outpoint))
   }
 }
 

--- a/ui/js/component/fileActions/index.js
+++ b/ui/js/component/fileActions/index.js
@@ -43,6 +43,7 @@ const makeSelect = () => {
   const selectIsAvailableForUri = makeSelectIsAvailableForUri()
   const selectDownloadingForUri = makeSelectDownloadingForUri()
   const selectCostInfoForUri = makeSelectCostInfoForUri()
+  const selectLoadingForUri = makeSelectLoadingForUri()
 
   const select = (state, props) => ({
     fileInfo: selectFileInfoForUri(state, props),
@@ -51,6 +52,7 @@ const makeSelect = () => {
     modal: selectCurrentModal(state),
     downloading: selectDownloadingForUri(state, props),
     costInfo: selectCostInfoForUri(state, props),
+    loading: selectLoadingForUri(state, props),
   })
 
   return select

--- a/ui/js/component/fileActions/view.jsx
+++ b/ui/js/component/fileActions/view.jsx
@@ -110,7 +110,6 @@ class FileActions extends React.Component {
       content  = <Link label="Open" button="text" icon="icon-folder-open" onClick={() => openInShell(fileInfo)} />;
     } else {
       console.log('handle this case of file action props?');
-      console.log(this.props)
     }
 
     return (

--- a/ui/js/component/fileActions/view.jsx
+++ b/ui/js/component/fileActions/view.jsx
@@ -63,6 +63,7 @@ class FileActions extends React.Component {
       closeModal,
       startDownload,
       costInfo,
+      loading,
     } = this.props
 
     const deleteChecked = this.state.deleteChecked,
@@ -73,9 +74,7 @@ class FileActions extends React.Component {
 
     let content
 
-    console.log(fileInfo)
-
-    if (downloading) {
+    if (loading || downloading) {
 
       const
         progress = (fileInfo && fileInfo.written_bytes) ? fileInfo.written_bytes / fileInfo.total_bytes * 100 : 0,

--- a/ui/js/component/fileActions/view.jsx
+++ b/ui/js/component/fileActions/view.jsx
@@ -73,6 +73,8 @@ class FileActions extends React.Component {
 
     let content
 
+    console.log(fileInfo)
+
     if (downloading) {
 
       const

--- a/ui/js/component/video/index.js
+++ b/ui/js/component/video/index.js
@@ -13,7 +13,8 @@ import {
   doLoadVideo,
 } from 'actions/content'
 import {
-  makeSelectMetadataForUri
+  makeSelectMetadataForUri,
+  makeSelectContentTypeForUri,
 } from 'selectors/claims'
 import {
   makeSelectFileInfoForUri,
@@ -32,6 +33,7 @@ const makeSelect = () => {
   const selectIsLoading = makeSelectLoadingForUri()
   const selectIsDownloading = makeSelectDownloadingForUri()
   const selectMetadata = makeSelectMetadataForUri()
+  const selectContentType = makeSelectContentTypeForUri()
 
   const select = (state, props) => ({
     costInfo: selectCostInfo(state, props),
@@ -40,6 +42,7 @@ const makeSelect = () => {
     modal: selectCurrentModal(state),
     isLoading: selectIsLoading(state, props),
     isDownloading: selectIsDownloading(state, props),
+    contentType: selectContentType(state, props),
   })
 
   return select

--- a/ui/js/component/video/view.jsx
+++ b/ui/js/component/video/view.jsx
@@ -126,7 +126,7 @@ class Video extends React.Component {
 
     return (
       <div className={klassName}>{
-        isPlaying || isLoading ?
+        isPlaying ?
           (!isReadyToPlay ?
             <span>this is the world's worst loading screen and we shipped our software with it anyway... <br /><br />{loadStatusMessage}</span> :
             <VideoPlayer filename={fileInfo.file_name} poster={poster} downloadPath={fileInfo.download_path} mediaType={mediaType} poster={poster} />) :

--- a/ui/js/lbry.js
+++ b/ui/js/lbry.js
@@ -286,7 +286,7 @@ lbry.imagePath = function(file)
 
 lbry.getMediaType = function(contentType, fileName) {
   if (contentType) {
-    return /^[^/]+/.exec(contentType);
+    return /^[^/]+/.exec(contentType)[0];
   } else if (fileName) {
     var dotIndex = fileName.lastIndexOf('.');
     if (dotIndex == -1) {

--- a/ui/js/page/filePage/view.jsx
+++ b/ui/js/page/filePage/view.jsx
@@ -92,11 +92,12 @@ class FilePage extends React.Component{
     const channelClaimId = claim.value && claim.value.publisherSignature ? claim.value.publisherSignature.certificateId : null;
     const channelUri = signatureIsValid && hasSignature && channelName ? lbryuri.build({channelName, claimId: channelClaimId}, false) : null
     const uriIndicator = <UriIndicator uri={uri} />
+    const mediaType = lbry.getMediaType(contentType)
 
     return (
       <main className="main--single-column">
         <section className="show-page-media">
-          { contentType && contentType.startsWith('video/') ?
+          { ["video", "audio", "image"].indexOf(mediaType) !== -1 ?
             <Video className="video-embedded" uri={uri} /> :
             (metadata && metadata.thumbnail ? <Thumbnail src={metadata.thumbnail} /> : <Thumbnail />) }
         </section>


### PR DESCRIPTION
A couple of things in this PR @kauffj 

Small tweaks:
- Scroll to the top of the page when changing path. This was really irritating me.
- Syncing up the loading status between the file actions and the video player. Can't click download on file actions when you're already loading from player and vice versa.

Big change:

- Use render-media to also render images and audio files (should also be able to do documents at some point too). I think it might be cool to rename all the `Video` stuff to `Media` soon too.

Images have a folder icon which renders on click. Audio renders an HTML5 audio tag below the thumbnail image. Not all audio types are seekable.

![filetypes](https://cloud.githubusercontent.com/assets/20863631/26717107/5948c936-47a6-11e7-975c-8f4853c9afb3.gif)


Perhaps we could render a waveform style player instead later on, and maybe an audio visualization instead of the thumbnail.

I think it would be awesome to make the media player stuff available on all pages. IMO it would be great if you could start something playing and it keeps playing at the bottom of the screen while you navigate around the app. Maybe with an option in the UI to add items to a playlist in the state
