### PR TITLE
Render all file types that render-media can handle

### DIFF
--- a/ui/js/component/video/view.jsx
+++ b/ui/js/component/video/view.jsx
@@ -49,7 +49,7 @@ class VideoPlayButton extends React.Component {
      */
 
     const disabled = isLoading || fileInfo === undefined || (fileInfo === null && (!costInfo || costInfo.cost === undefined))
-    const icon = mediaType == "image" ? "icon-folder-o" : "icon-play"
+    const icon = ["audio", "video"].indexOf(mediaType) !== -1 ? "icon-play" : "icon-folder-o"
 
     return (<div>
       <Link button={ button ? button : null }
@@ -119,6 +119,8 @@ class Video extends React.Component {
     if (mediaType === "video") {
       klassName += "video-embedded video"
       klassName += isPlaying ? " video--active" : " video--hidden"
+    } else if (mediaType === "application") {
+      klassName += "video-embedded"
     } else {
       if (!isPlaying) klassName += "video-embedded"
     }
@@ -170,7 +172,7 @@ class VideoPlayer extends React.Component {
 
     return (
       <div>
-        {mediaType === "audio" && <Thumbnail src={poster} className="video-embedded" />}
+        {["audio", "application"].indexOf(mediaType) !== -1 && <Thumbnail src={poster} className="video-embedded" />}
         <div ref="media" />
       </div>
     )

--- a/ui/js/page/filePage/view.jsx
+++ b/ui/js/page/filePage/view.jsx
@@ -93,11 +93,14 @@ class FilePage extends React.Component{
     const channelUri = signatureIsValid && hasSignature && channelName ? lbryuri.build({channelName, claimId: channelClaimId}, false) : null
     const uriIndicator = <UriIndicator uri={uri} />
     const mediaType = lbry.getMediaType(contentType)
+    const player = require('render-media')
+    const isPlayable = Object.values(player.mime).indexOf(contentType) !== -1 ||
+      mediaType === "audio"
 
     return (
       <main className="main--single-column">
         <section className="show-page-media">
-          { ["video", "audio", "image"].indexOf(mediaType) !== -1 ?
+          { isPlayable ?
             <Video className="video-embedded" uri={uri} /> :
             (metadata && metadata.thumbnail ? <Thumbnail src={metadata.thumbnail} /> : <Thumbnail />) }
         </section>

--- a/ui/scss/page/_show.scss
+++ b/ui/scss/page/_show.scss
@@ -6,4 +6,9 @@
   img {
     max-width: 100%;
   }
+
+  iframe {
+    width: 100%;
+    min-height: 500px;
+  }
 }


### PR DESCRIPTION
I've added all the other types that `render-media` can play @kauffj.

It renders documents into an iframe. This could be a security vulnerability. I tried adding some HTML with JS and couldn't get anything to run, but looking at the `render-media` source, it seems that it does allow scripts somehow https://github.com/feross/render-media/blob/master/index.js#L282.

![filetypes](https://cloud.githubusercontent.com/assets/20863631/26739602/a163caa8-47fc-11e7-8bc1-ef9a685fd594.gif)
