### PR TITLE
Update video player loading screen

### DIFF
--- a/ui/js/component/video/internal/loading-screen.jsx
+++ b/ui/js/component/video/internal/loading-screen.jsx
@@ -1,11 +1,11 @@
 import React from "react";
 
-const LoadingScreen = ({ statusMessage }) =>
+const LoadingScreen = ({ status }) =>
   <div className="video--loading--screen">
     <div className="loading--spinner" />
 
     <div className="video--loading--status">
-      {statusMessage}
+      {status}
     </div>
   </div>;
 

--- a/ui/js/component/video/internal/loading-screen.jsx
+++ b/ui/js/component/video/internal/loading-screen.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+const LoadingScreen = ({ statusMessage }) =>
+  <div className="video--loading--screen">
+    <div className="loading--spinner" />
+
+    <div>
+      {statusMessage}
+    </div>
+  </div>;
+
+export default LoadingScreen;

--- a/ui/js/component/video/internal/loading-screen.jsx
+++ b/ui/js/component/video/internal/loading-screen.jsx
@@ -1,11 +1,11 @@
 import React from "react";
 
 const LoadingScreen = ({ status }) =>
-  <div className="video--loading--screen">
-    <div className="loading--screen--content">
-      <div className="loading--spinner" />
+  <div className="video--loading-screen">
+    <div className="video--loading-screen-content">
+      <div className="video--loading-spinner" />
 
-      <div className="video--loading--status">
+      <div className="video--loading-status">
         {status}
       </div>
     </div>

--- a/ui/js/component/video/internal/loading-screen.jsx
+++ b/ui/js/component/video/internal/loading-screen.jsx
@@ -2,10 +2,12 @@ import React from "react";
 
 const LoadingScreen = ({ status }) =>
   <div className="video--loading--screen">
-    <div className="loading--spinner" />
+    <div className="loading--screen--content">
+      <div className="loading--spinner" />
 
-    <div className="video--loading--status">
-      {status}
+      <div className="video--loading--status">
+        {status}
+      </div>
     </div>
   </div>;
 

--- a/ui/js/component/video/internal/loading-screen.jsx
+++ b/ui/js/component/video/internal/loading-screen.jsx
@@ -4,7 +4,7 @@ const LoadingScreen = ({ statusMessage }) =>
   <div className="video--loading--screen">
     <div className="loading--spinner" />
 
-    <div>
+    <div className="video--loading--status">
       {statusMessage}
     </div>
   </div>;

--- a/ui/js/component/video/internal/play-button.jsx
+++ b/ui/js/component/video/internal/play-button.jsx
@@ -1,0 +1,93 @@
+import React from "react";
+import FilePrice from "component/filePrice";
+import Link from "component/link";
+import Modal from "component/modal";
+
+class VideoPlayButton extends React.Component {
+  onPurchaseConfirmed() {
+    this.props.closeModal();
+    this.props.startPlaying();
+    this.props.loadVideo(this.props.uri);
+  }
+
+  onWatchClick() {
+    this.props.purchaseUri(this.props.uri).then(() => {
+      if (!this.props.modal) {
+        this.props.startPlaying();
+      }
+    });
+  }
+
+  render() {
+    const {
+      button,
+      label,
+      className,
+      metadata,
+      metadata: { title },
+      uri,
+      modal,
+      closeModal,
+      isLoading,
+      costInfo,
+      fileInfo,
+      mediaType,
+    } = this.props;
+
+    /*
+     title={
+     isLoading ? "Video is Loading" :
+     !costInfo ? "Waiting on cost info..." :
+     fileInfo === undefined ? "Waiting on file info..." : ""
+     }
+     */
+
+    const disabled =
+      isLoading ||
+      fileInfo === undefined ||
+      (fileInfo === null && (!costInfo || costInfo.cost === undefined));
+    const icon = ["audio", "video"].indexOf(mediaType) !== -1
+      ? "icon-play"
+      : "icon-folder-o";
+
+    return (
+      <div>
+        <Link
+          button={button ? button : null}
+          disabled={disabled}
+          label={label ? label : ""}
+          className="video__play-button"
+          icon={icon}
+          onClick={this.onWatchClick.bind(this)}
+        />
+        <Modal
+          contentLabel={__("Not enough credits")}
+          isOpen={modal == "notEnoughCredits"}
+          onConfirmed={closeModal}
+        >
+          {__("You don't have enough LBRY credits to pay for this stream.")}
+        </Modal>
+        <Modal
+          type="confirm"
+          isOpen={modal == "affirmPurchaseAndPlay"}
+          contentLabel={__("Confirm Purchase")}
+          onConfirmed={this.onPurchaseConfirmed.bind(this)}
+          onAborted={closeModal}
+        >
+          {__("This will purchase")} <strong>{title}</strong> {__("for")}
+          {" "}<strong><FilePrice uri={uri} look="plain" /></strong>
+          {" "}{__("credits")}.
+        </Modal>
+        <Modal
+          isOpen={modal == "timedOut"}
+          onConfirmed={closeModal}
+          contentLabel={__("Timed Out")}
+        >
+          {__("Sorry, your download timed out :(")}
+        </Modal>
+      </div>
+    );
+  }
+}
+
+export default VideoPlayButton;

--- a/ui/js/component/video/internal/player.jsx
+++ b/ui/js/component/video/internal/player.jsx
@@ -2,7 +2,6 @@ import React from "react";
 import { Thumbnail } from "component/common";
 import player from "render-media";
 import fs from "fs";
-// const from = require("from2");
 
 class VideoPlayer extends React.Component {
   componentDidMount() {

--- a/ui/js/component/video/internal/player.jsx
+++ b/ui/js/component/video/internal/player.jsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { Thumbnail } from "component/common";
+import player from "render-media";
+import fs from "fs";
+// const from = require("from2");
+
+class VideoPlayer extends React.Component {
+  componentDidMount() {
+    const elem = this.refs.media;
+    const { downloadPath, filename } = this.props;
+    const file = {
+      name: filename,
+      createReadStream: opts => {
+        return fs.createReadStream(downloadPath, opts);
+      },
+    };
+    player.append(file, elem, {
+      autoplay: true,
+      controls: true,
+    });
+  }
+
+  render() {
+    const { downloadPath, mediaType, poster } = this.props;
+
+    return (
+      <div>
+        {["audio", "application"].indexOf(mediaType) !== -1 &&
+          <Thumbnail src={poster} className="video-embedded" />}
+        <div ref="media" />
+      </div>
+    );
+  }
+}
+
+export default VideoPlayer;

--- a/ui/js/component/video/view.jsx
+++ b/ui/js/component/video/view.jsx
@@ -4,6 +4,7 @@ import Link from "component/link";
 import Modal from "component/modal";
 import lbry from "lbry";
 import { Thumbnail } from "component/common";
+import LoadingScreen from "./internal/loading-screen";
 
 class VideoPlayButton extends React.Component {
   onPurchaseConfirmed() {
@@ -148,31 +149,27 @@ class Video extends React.Component {
 
     return (
       <div className={klassName}>
-        {isPlaying
-          ? !isReadyToPlay
-            ? <span>
-                {__(
-                  "this is the world's worst loading screen and we shipped our software with it anyway..."
-                )}
-                {" "}<br /><br />{loadStatusMessage}
-              </span>
+        {isPlaying &&
+          (!isReadyToPlay
+            ? <LoadingScreen status={loadStatusMessage} />
             : <VideoPlayer
                 filename={fileInfo.file_name}
                 poster={poster}
                 downloadPath={fileInfo.download_path}
                 mediaType={mediaType}
                 poster={poster}
-              />
-          : <div
-              className="video__cover"
-              style={{ backgroundImage: 'url("' + metadata.thumbnail + '")' }}
-            >
-              <VideoPlayButton
-                startPlaying={this.startPlaying.bind(this)}
-                {...this.props}
-                mediaType={mediaType}
-              />
-            </div>}
+              />)}
+        {!isPlaying &&
+          <div
+            className="video__cover"
+            style={{ backgroundImage: 'url("' + metadata.thumbnail + '")' }}
+          >
+            <VideoPlayButton
+              startPlaying={this.startPlaying.bind(this)}
+              {...this.props}
+              mediaType={mediaType}
+            />
+          </div>}
       </div>
     );
   }

--- a/ui/js/component/video/view.jsx
+++ b/ui/js/component/video/view.jsx
@@ -1,97 +1,8 @@
 import React from "react";
-import FilePrice from "component/filePrice";
-import Link from "component/link";
-import Modal from "component/modal";
 import lbry from "lbry";
-import { Thumbnail } from "component/common";
+import VideoPlayer from "./internal/player";
+import VideoPlayButton from "./internal/play-button";
 import LoadingScreen from "./internal/loading-screen";
-
-class VideoPlayButton extends React.Component {
-  onPurchaseConfirmed() {
-    this.props.closeModal();
-    this.props.startPlaying();
-    this.props.loadVideo(this.props.uri);
-  }
-
-  onWatchClick() {
-    this.props.purchaseUri(this.props.uri).then(() => {
-      if (!this.props.modal) {
-        this.props.startPlaying();
-      }
-    });
-  }
-
-  render() {
-    const {
-      button,
-      label,
-      className,
-      metadata,
-      metadata: { title },
-      uri,
-      modal,
-      closeModal,
-      isLoading,
-      costInfo,
-      fileInfo,
-      mediaType,
-    } = this.props;
-
-    /*
-     title={
-     isLoading ? "Video is Loading" :
-     !costInfo ? "Waiting on cost info..." :
-     fileInfo === undefined ? "Waiting on file info..." : ""
-     }
-     */
-
-    const disabled =
-      isLoading ||
-      fileInfo === undefined ||
-      (fileInfo === null && (!costInfo || costInfo.cost === undefined));
-    const icon = ["audio", "video"].indexOf(mediaType) !== -1
-      ? "icon-play"
-      : "icon-folder-o";
-
-    return (
-      <div>
-        <Link
-          button={button ? button : null}
-          disabled={disabled}
-          label={label ? label : ""}
-          className="video__play-button"
-          icon={icon}
-          onClick={this.onWatchClick.bind(this)}
-        />
-        <Modal
-          contentLabel={__("Not enough credits")}
-          isOpen={modal == "notEnoughCredits"}
-          onConfirmed={closeModal}
-        >
-          {__("You don't have enough LBRY credits to pay for this stream.")}
-        </Modal>
-        <Modal
-          type="confirm"
-          isOpen={modal == "affirmPurchaseAndPlay"}
-          contentLabel={__("Confirm Purchase")}
-          onConfirmed={this.onPurchaseConfirmed.bind(this)}
-          onAborted={closeModal}
-        >
-          {__("This will purchase")} <strong>{title}</strong> {__("for")}
-          {" "}<strong><FilePrice uri={uri} look="plain" /></strong>
-          {" "}{__("credits")}.
-        </Modal>
-        <Modal
-          isOpen={modal == "timedOut"}
-          onConfirmed={closeModal}
-          contentLabel={__("Timed Out")}
-        >
-          {__("Sorry, your download timed out :(")}
-        </Modal>
-      </div>
-    );
-  }
-}
 
 class Video extends React.Component {
   constructor(props) {
@@ -170,39 +81,6 @@ class Video extends React.Component {
               mediaType={mediaType}
             />
           </div>}
-      </div>
-    );
-  }
-}
-
-const from = require("from2");
-const player = require("render-media");
-const fs = require("fs");
-
-class VideoPlayer extends React.Component {
-  componentDidMount() {
-    const elem = this.refs.media;
-    const { downloadPath, filename } = this.props;
-    const file = {
-      name: filename,
-      createReadStream: opts => {
-        return fs.createReadStream(downloadPath, opts);
-      },
-    };
-    player.append(file, elem, {
-      autoplay: true,
-      controls: true,
-    });
-  }
-
-  render() {
-    const { downloadPath, mediaType, poster } = this.props;
-
-    return (
-      <div>
-        {["audio", "application"].indexOf(mediaType) !== -1 &&
-          <Thumbnail src={poster} className="video-embedded" />}
-        <div ref="media" />
       </div>
     );
   }

--- a/ui/scss/component/_video.scss
+++ b/ui/scss/component/_video.scss
@@ -29,25 +29,64 @@ video {
   }
 
   .video--loading--screen {
-    .loading--spinner {
-      width: 100px;
-      height: 100px;
-      background-color: white;
-      margin: auto;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 
-      animation-name: spin;
-      animation-duration: 1s;
-      animation-iteration-count: infinite;
-      animation-timing-function: linear;
+    .loading--screen--content {
+      .loading--spinner {
+        position: relative;
+        width: 11em;
+        height: 11em;
+        margin: 20px auto;
+        font-size: 3px;
+        border-radius: 50%;
 
-      @keyframes spin {
-        from { transform: rotate(0deg) }
-        to { transform: rotate(-360deg) }
+        background: linear-gradient(to right, #ffffff 10%, rgba(255, 255, 255, 0) 50%);
+        animation: spin 1.4s infinite linear;
+        transform: translateZ(0);
+
+        @keyframes spin {
+          from {
+            transform: rotate(0deg);
+          }
+          to {
+            transform: rotate(360deg);
+          }
+        }
+
+        &:before,
+        &:after {
+          content: '';
+          position: absolute;
+          top: 0;
+          left: 0;
+        }
+
+        &:before {
+          width: 50%;
+          height: 50%;
+          background: #ffffff;
+          border-radius: 100% 0 0 0;
+        }
+
+        &:after {
+          height: 75%;
+          width: 75%;
+          margin: auto;
+          bottom: 0;
+          right: 0;
+          background: black;
+          border-radius: 50%;
+        }
       }
-    }
-    
-    .video--loading--status {
-      color: white;
+
+
+      .video--loading--status {
+        padding-top: 20px;
+        color: white;
+      }
     }
   }
 

--- a/ui/scss/component/_video.scss
+++ b/ui/scss/component/_video.scss
@@ -45,6 +45,10 @@ video {
         to { transform: rotate(-360deg) }
       }
     }
+    
+    .video--loading--status {
+      color: white;
+    }
   }
 
   .plyr {

--- a/ui/scss/component/_video.scss
+++ b/ui/scss/component/_video.scss
@@ -13,7 +13,6 @@ video {
   color: white;
 }
 
-
 .video-embedded {
   max-width: $width-page-constrained;
   max-height: $height-video-embedded;
@@ -28,6 +27,26 @@ video {
   &.video--active {
     /*background: none;*/
   }
+
+  .video--loading--screen {
+    .loading--spinner {
+      width: 100px;
+      height: 100px;
+      background-color: white;
+      margin: auto;
+
+      animation-name: spin;
+      animation-duration: 1s;
+      animation-iteration-count: infinite;
+      animation-timing-function: linear;
+
+      @keyframes spin {
+        from { transform: rotate(0deg) }
+        to { transform: rotate(-360deg) }
+      }
+    }
+  }
+
   .plyr {
     top: 50%;
     transform: translateY(-50%);

--- a/ui/scss/component/_video.scss
+++ b/ui/scss/component/_video.scss
@@ -28,72 +28,70 @@ video {
     /*background: none;*/
   }
 
-  .video--loading--screen {
-    height: 100%;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-
-    .loading--screen--content {
-      .loading--spinner {
-        position: relative;
-        width: 11em;
-        height: 11em;
-        margin: 20px auto;
-        font-size: 3px;
-        border-radius: 50%;
-
-        background: linear-gradient(to right, #ffffff 10%, rgba(255, 255, 255, 0) 50%);
-        animation: spin 1.4s infinite linear;
-        transform: translateZ(0);
-
-        @keyframes spin {
-          from {
-            transform: rotate(0deg);
-          }
-          to {
-            transform: rotate(360deg);
-          }
-        }
-
-        &:before,
-        &:after {
-          content: '';
-          position: absolute;
-          top: 0;
-          left: 0;
-        }
-
-        &:before {
-          width: 50%;
-          height: 50%;
-          background: #ffffff;
-          border-radius: 100% 0 0 0;
-        }
-
-        &:after {
-          height: 75%;
-          width: 75%;
-          margin: auto;
-          bottom: 0;
-          right: 0;
-          background: black;
-          border-radius: 50%;
-        }
-      }
-
-
-      .video--loading--status {
-        padding-top: 20px;
-        color: white;
-      }
-    }
-  }
-
   .plyr {
     top: 50%;
     transform: translateY(-50%);
   }
+}
+
+
+.video--loading-screen {
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.video--loading-spinner {
+  position: relative;
+  width: 11em;
+  height: 11em;
+  margin: 20px auto;
+  font-size: 3px;
+  border-radius: 50%;
+
+  background: linear-gradient(to right, #ffffff 10%, rgba(255, 255, 255, 0) 50%);
+  animation: spin 1.4s infinite linear;
+  transform: translateZ(0);
+
+  @keyframes spin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  &:before,
+  &:after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+
+  &:before {
+    width: 50%;
+    height: 50%;
+    background: #ffffff;
+    border-radius: 100% 0 0 0;
+  }
+
+  &:after {
+    height: 75%;
+    width: 75%;
+    margin: auto;
+    bottom: 0;
+    right: 0;
+    background: black;
+    border-radius: 50%;
+  }
+}
+
+.video--loading-status {
+  padding-top: 20px;
+  color: white;
 }
 
 .video__cover {


### PR DESCRIPTION
### Summary

The goal of this is to add a slightly better-looking video player loading screen and set a folder tree structure for internal components. In this PR I have created a folder called `internal` inside of the `video` component folder. Currently, the components are separated by name into folders, but they only have a single `.jsx` file for the main component, as well as any other internal components needed to build the main component.

This leads to huge React files with many components which can make it hard to follow the component tree. I think we should set a style now and try to adhere to it as components grow.

The structure added in this PR is:
```
component/
  ...
  video/
      internal/
          some-internal-comp.jsx // some component that is imported by view.jsx
      view.jsx // the base component
      index.js // connects base component to store

  ...
```

### How it looks

![loading](https://user-images.githubusercontent.com/16882830/26866412-d8fe584a-4b15-11e7-9f45-84d5a44b2409.gif)
