### PR TITLE
Fixed the local version in help

### DIFF
--- a/ui/js/page/help/view.jsx
+++ b/ui/js/page/help/view.jsx
@@ -18,12 +18,14 @@ class HelpPage extends React.Component {
   }
 
   componentWillMount() {
-    lbry.getAppVersionInfo().then(({ remoteVersion, upgradeAvailable }) => {
-      this.setState({
-        uiVersion: remoteVersion,
-        upgradeAvailable: upgradeAvailable,
+    lbry
+      .getAppVersionInfo()
+      .then(({ remoteVersion, localVersion, upgradeAvailable }) => {
+        this.setState({
+          uiVersion: localVersion,
+          upgradeAvailable: upgradeAvailable,
+        });
       });
-    });
     lbry.call("version", {}, info => {
       this.setState({
         versionInfo: info,


### PR DESCRIPTION
This commit fixes the version in the help page.
Before it displayed the last remote version, now it displays the "localVersion".