### PR TITLE
allow user to create new directory when choosing download directory

### DIFF
--- a/ui/js/component/file-selector.js
+++ b/ui/js/component/file-selector.js
@@ -21,7 +21,9 @@ class FileSelector extends React.PureComponent {
   handleButtonClick() {
     remote.dialog.showOpenDialog(
       {
-        properties: [this.props.type == "file" ? "openFile" : "openDirectory"],
+        properties: this.props.type == "file"
+          ? ["openFile"]
+          : ["openDirectory", "createDirectory"],
       },
       paths => {
         if (!paths) {


### PR DESCRIPTION
### Summary
For https://github.com/lbryio/lbry-app/issues/234
Add `createDirectory` property to the `showOpenDialog` call

<img width="450" alt="screen shot 2017-06-14 at 9 05 56 pm" src="https://user-images.githubusercontent.com/16882830/27164922-66b72074-5145-11e7-921b-28d962afa85a.png">
