### PR TITLE
Always refresh claims/file info on downloaded/published pages

### DIFF
--- a/ui/js/actions/file_info.js
+++ b/ui/js/actions/file_info.js
@@ -98,16 +98,9 @@ export function doDeleteFile(outpoint, deleteFromComputer) {
 
 export function doFetchFileInfosAndPublishedClaims() {
   return function(dispatch, getState) {
-    const state = getState(),
-      isClaimListMinePending = selectClaimListMineIsPending(state),
-      isFileInfoListPending = selectFileListIsPending(state);
+    const state = getState();
 
-    if (isClaimListMinePending === undefined) {
-      dispatch(doFetchClaimListMine());
-    }
-
-    if (isFileInfoListPending === undefined) {
-      dispatch(doFileList());
-    }
+    dispatch(doFetchClaimListMine());
+    dispatch(doFileList());
   };
 }

--- a/ui/js/component/fileList/view.jsx
+++ b/ui/js/component/fileList/view.jsx
@@ -82,7 +82,7 @@ class FileList extends React.PureComponent {
     });
     return (
       <section className="file-list__header">
-        {fetching && <span className="busy-indicator" />}
+        {fetching && <BusyMessage />}
         <span className="sort-section">
           {__("Sort by")} {" "}
           <FormField type="select" onChange={this.handleSortChanged.bind(this)}>

--- a/ui/js/component/fileTile/view.jsx
+++ b/ui/js/component/fileTile/view.jsx
@@ -19,14 +19,14 @@ class FileTile extends React.PureComponent {
   }
 
   componentDidMount() {
-    this.resolve(this.props);
+    const { isResolvingUri, claim, uri, resolveUri } = this.props;
+
+    if (!isResolvingUri && !claim && uri) resolveUri(uri);
   }
 
   componentWillReceiveProps(nextProps) {
-    this.resolve(nextProps);
-  }
+    const { isResolvingUri, claim, uri, resolveUri } = this.props;
 
-  resolve({ isResolvingUri, claim, uri, resolveUri }) {
     if (!isResolvingUri && claim === undefined && uri) resolveUri(uri);
   }
 

--- a/ui/js/lbry.js
+++ b/ui/js/lbry.js
@@ -1,25 +1,25 @@
-import lbryio from './lbryio.js';
-import lighthouse from './lighthouse.js';
-import jsonrpc from './jsonrpc.js';
-import lbryuri from './lbryuri.js';
-import { getLocal, getSession, setSession, setLocal } from './utils.js';
+import lbryio from "./lbryio.js";
+import lighthouse from "./lighthouse.js";
+import jsonrpc from "./jsonrpc.js";
+import lbryuri from "./lbryuri.js";
+import { getLocal, getSession, setSession, setLocal } from "./utils.js";
 
-const { remote, ipcRenderer } = require('electron');
-const menu = remote.require('./menu/main-menu');
+const { remote, ipcRenderer } = require("electron");
+const menu = remote.require("./menu/main-menu");
 
 let lbry = {
-	isConnected: false,
-	daemonConnectionString: 'http://localhost:5279/lbryapi',
-	pendingPublishTimeout: 20 * 60 * 1000,
-	defaultClientSettings: {
-		showNsfw: false,
-		showUnavailable: true,
-		debug: false,
-		useCustomLighthouseServers: false,
-		customLighthouseServers: [],
-		showDeveloperMenu: false,
-		language: 'en'
-	}
+  isConnected: false,
+  daemonConnectionString: "http://localhost:5279/lbryapi",
+  pendingPublishTimeout: 20 * 60 * 1000,
+  defaultClientSettings: {
+    showNsfw: false,
+    showUnavailable: true,
+    debug: false,
+    useCustomLighthouseServers: false,
+    customLighthouseServers: [],
+    showDeveloperMenu: false,
+    language: "en",
+  },
 };
 
 /**
@@ -27,24 +27,24 @@ let lbry = {
  * needed to make a dummy claim or file info object.
  */
 function savePendingPublish({ name, channel_name }) {
-	let uri;
-	if (channel_name) {
-		uri = lbryuri.build({ name: channel_name, path: name }, false);
-	} else {
-		uri = lbryuri.build({ name: name }, false);
-	}
-	const pendingPublishes = getLocal('pendingPublishes') || [];
-	const newPendingPublish = {
-		name,
-		channel_name,
-		claim_id: 'pending_claim_' + uri,
-		txid: 'pending_' + uri,
-		nout: 0,
-		outpoint: 'pending_' + uri + ':0',
-		time: Date.now()
-	};
-	setLocal('pendingPublishes', [...pendingPublishes, newPendingPublish]);
-	return newPendingPublish;
+  let uri;
+  if (channel_name) {
+    uri = lbryuri.build({ name: channel_name, path: name }, false);
+  } else {
+    uri = lbryuri.build({ name: name }, false);
+  }
+  const pendingPublishes = getLocal("pendingPublishes") || [];
+  const newPendingPublish = {
+    name,
+    channel_name,
+    claim_id: "pending_claim_" + uri,
+    txid: "pending_" + uri,
+    nout: 0,
+    outpoint: "pending_" + uri + ":0",
+    time: Date.now(),
+  };
+  setLocal("pendingPublishes", [...pendingPublishes, newPendingPublish]);
+  return newPendingPublish;
 }
 
 /**
@@ -52,18 +52,18 @@ function savePendingPublish({ name, channel_name }) {
  * A channel name may also be provided along with name.
  */
 function removePendingPublishIfNeeded({ name, channel_name, outpoint }) {
-	function pubMatches(pub) {
-		return (
-			pub.outpoint === outpoint ||
-			(pub.name === name &&
-				(!channel_name || pub.channel_name === channel_name))
-		);
-	}
+  function pubMatches(pub) {
+    return (
+      pub.outpoint === outpoint ||
+      (pub.name === name &&
+        (!channel_name || pub.channel_name === channel_name))
+    );
+  }
 
-	setLocal(
-		'pendingPublishes',
-		lbry.getPendingPublishes().filter(pub => !pubMatches(pub))
-	);
+  setLocal(
+    "pendingPublishes",
+    lbry.getPendingPublishes().filter(pub => !pubMatches(pub))
+  );
 }
 
 /**
@@ -71,12 +71,12 @@ function removePendingPublishIfNeeded({ name, channel_name, outpoint }) {
  * removes them from the list.
  */
 lbry.getPendingPublishes = function() {
-	const pendingPublishes = getLocal('pendingPublishes') || [];
-	const newPendingPublishes = pendingPublishes.filter(
-		pub => Date.now() - pub.time <= lbry.pendingPublishTimeout
-	);
-	setLocal('pendingPublishes', newPendingPublishes);
-	return newPendingPublishes;
+  const pendingPublishes = getLocal("pendingPublishes") || [];
+  const newPendingPublishes = pendingPublishes.filter(
+    pub => Date.now() - pub.time <= lbry.pendingPublishTimeout
+  );
+  setLocal("pendingPublishes", newPendingPublishes);
+  return newPendingPublishes;
 };
 
 /**
@@ -84,97 +84,97 @@ lbry.getPendingPublishes = function() {
  * provided along withe the name. If no pending publish is found, returns null.
  */
 function getPendingPublish({ name, channel_name, outpoint }) {
-	const pendingPublishes = lbry.getPendingPublishes();
-	return (
-		pendingPublishes.find(
-			pub =>
-				pub.outpoint === outpoint ||
-				(pub.name === name &&
-					(!channel_name || pub.channel_name === channel_name))
-		) || null
-	);
+  const pendingPublishes = lbry.getPendingPublishes();
+  return (
+    pendingPublishes.find(
+      pub =>
+        pub.outpoint === outpoint ||
+        (pub.name === name &&
+          (!channel_name || pub.channel_name === channel_name))
+    ) || null
+  );
 }
 
 function pendingPublishToDummyClaim({
-	channel_name,
-	name,
-	outpoint,
-	claim_id,
-	txid,
-	nout
+  channel_name,
+  name,
+  outpoint,
+  claim_id,
+  txid,
+  nout,
 }) {
-	return { name, outpoint, claim_id, txid, nout, channel_name };
+  return { name, outpoint, claim_id, txid, nout, channel_name };
 }
 
 function pendingPublishToDummyFileInfo({ name, outpoint, claim_id }) {
-	return { name, outpoint, claim_id, metadata: null };
+  return { name, outpoint, claim_id, metadata: null };
 }
 
 lbry.call = function(
-	method,
-	params,
-	callback,
-	errorCallback,
-	connectFailedCallback
+  method,
+  params,
+  callback,
+  errorCallback,
+  connectFailedCallback
 ) {
-	return jsonrpc.call(
-		lbry.daemonConnectionString,
-		method,
-		params,
-		callback,
-		errorCallback,
-		connectFailedCallback
-	);
+  return jsonrpc.call(
+    lbry.daemonConnectionString,
+    method,
+    params,
+    callback,
+    errorCallback,
+    connectFailedCallback
+  );
 };
 
 //core
 lbry._connectPromise = null;
 lbry.connect = function() {
-	if (lbry._connectPromise === null) {
-		lbry._connectPromise = new Promise((resolve, reject) => {
-			let tryNum = 0;
+  if (lbry._connectPromise === null) {
+    lbry._connectPromise = new Promise((resolve, reject) => {
+      let tryNum = 0;
 
-			function checkDaemonStartedFailed() {
-				if (tryNum <= 100) {
-					// Move # of tries into constant or config option
-					setTimeout(() => {
-						tryNum++;
-						checkDaemonStarted();
-					}, tryNum < 50 ? 400 : 1000);
-				} else {
-					reject(new Error('Unable to connect to LBRY'));
-				}
-			}
+      function checkDaemonStartedFailed() {
+        if (tryNum <= 100) {
+          // Move # of tries into constant or config option
+          setTimeout(() => {
+            tryNum++;
+            checkDaemonStarted();
+          }, tryNum < 50 ? 400 : 1000);
+        } else {
+          reject(new Error("Unable to connect to LBRY"));
+        }
+      }
 
-			// Check every half second to see if the daemon is accepting connections
-			function checkDaemonStarted() {
-				lbry.call(
-					'status',
-					{},
-					resolve,
-					checkDaemonStartedFailed,
-					checkDaemonStartedFailed
-				);
-			}
+      // Check every half second to see if the daemon is accepting connections
+      function checkDaemonStarted() {
+        lbry.call(
+          "status",
+          {},
+          resolve,
+          checkDaemonStartedFailed,
+          checkDaemonStartedFailed
+        );
+      }
 
-			checkDaemonStarted();
-		});
-	}
+      checkDaemonStarted();
+    });
+  }
 
-	return lbry._connectPromise;
+  return lbry._connectPromise;
 };
 
 lbry.checkAddressIsMine = function(address, callback) {
-	lbry.call('wallet_is_address_mine', { address: address }, callback);
+  lbry.call("wallet_is_address_mine", { address: address }, callback);
 };
 
 lbry.sendToAddress = function(amount, address, callback, errorCallback) {
-	lbry.call(
-		'send_amount_to_address',
-		{ amount: amount, address: address },
-		callback,
-		errorCallback
-	);
+  lbry.call(
+    "send_amount_to_address",
+    { amount: amount, address: address },
+    callback,
+    errorCallback
+  );
 };
 
 /**
@@ -189,46 +189,46 @@ lbry.sendToAddress = function(amount, address, callback, errorCallback) {
  */
 lbry.costPromiseCache = {};
 lbry.getCostInfo = function(uri) {
-	if (lbry.costPromiseCache[uri] === undefined) {
-		lbry.costPromiseCache[uri] = new Promise((resolve, reject) => {
-			const COST_INFO_CACHE_KEY = 'cost_info_cache';
-			let costInfoCache = getSession(COST_INFO_CACHE_KEY, {});
+  if (lbry.costPromiseCache[uri] === undefined) {
+    lbry.costPromiseCache[uri] = new Promise((resolve, reject) => {
+      const COST_INFO_CACHE_KEY = "cost_info_cache";
+      let costInfoCache = getSession(COST_INFO_CACHE_KEY, {});
 
-			function cacheAndResolve(cost, includesData) {
-				costInfoCache[uri] = { cost, includesData };
-				setSession(COST_INFO_CACHE_KEY, costInfoCache);
-				resolve({ cost, includesData });
-			}
+      function cacheAndResolve(cost, includesData) {
+        costInfoCache[uri] = { cost, includesData };
+        setSession(COST_INFO_CACHE_KEY, costInfoCache);
+        resolve({ cost, includesData });
+      }
 
-			if (!uri) {
-				return reject(new Error(`URI required.`));
-			}
+      if (!uri) {
+        return reject(new Error(`URI required.`));
+      }
 
-			if (costInfoCache[uri] && costInfoCache[uri].cost) {
-				return resolve(costInfoCache[uri]);
-			}
+      if (costInfoCache[uri] && costInfoCache[uri].cost) {
+        return resolve(costInfoCache[uri]);
+      }
 
-			function getCost(uri, size) {
-				lbry
-					.stream_cost_estimate({ uri, ...(size !== null ? { size } : {}) })
-					.then(cost => {
-						cacheAndResolve(cost, size !== null);
-					}, reject);
-			}
+      function getCost(uri, size) {
+        lbry
+          .stream_cost_estimate({ uri, ...(size !== null ? { size } : {}) })
+          .then(cost => {
+            cacheAndResolve(cost, size !== null);
+          }, reject);
+      }
 
-			const uriObj = lbryuri.parse(uri);
-			const name = uriObj.path || uriObj.name;
+      const uriObj = lbryuri.parse(uri);
+      const name = uriObj.path || uriObj.name;
 
-			lighthouse.get_size_for_name(name).then(size => {
-				if (size) {
-					getCost(name, size);
-				} else {
-					getCost(name, null);
-				}
-			});
-		});
-	}
-	return lbry.costPromiseCache[uri];
+      lighthouse.get_size_for_name(name).then(size => {
+        if (size) {
+          getCost(name, size);
+        } else {
+          getCost(name, null);
+        }
+      });
+    });
+  }
+  return lbry.costPromiseCache[uri];
 };
 
 /**
@@ -239,143 +239,143 @@ lbry.getCostInfo = function(uri) {
  * publish can appear in the UI immediately.
  */
 lbry.publish = function(
-	params,
-	fileListedCallback,
-	publishedCallback,
-	errorCallback
+  params,
+  fileListedCallback,
+  publishedCallback,
+  errorCallback
 ) {
-	lbry.call(
-		'publish',
-		params,
-		result => {
-			if (returnedPending) {
-				return;
-			}
+  lbry.call(
+    "publish",
+    params,
+    result => {
+      if (returnedPending) {
+        return;
+      }
 
-			clearTimeout(returnPendingTimeout);
-			publishedCallback(result);
-		},
-		err => {
-			if (returnedPending) {
-				return;
-			}
+      clearTimeout(returnPendingTimeout);
+      publishedCallback(result);
+    },
+    err => {
+      if (returnedPending) {
+        return;
+      }
 
-			clearTimeout(returnPendingTimeout);
-			errorCallback(err);
-		}
-	);
+      clearTimeout(returnPendingTimeout);
+      errorCallback(err);
+    }
+  );
 
-	let returnedPending = false;
-	// Give a short grace period in case publish() returns right away or (more likely) gives an error
-	const returnPendingTimeout = setTimeout(() => {
-		returnedPending = true;
+  let returnedPending = false;
+  // Give a short grace period in case publish() returns right away or (more likely) gives an error
+  const returnPendingTimeout = setTimeout(() => {
+    returnedPending = true;
 
-		if (publishedCallback) {
-			savePendingPublish({
-				name: params.name,
-				channel_name: params.channel_name
-			});
-			publishedCallback(true);
-		}
+    if (publishedCallback) {
+      savePendingPublish({
+        name: params.name,
+        channel_name: params.channel_name,
+      });
+      publishedCallback(true);
+    }
 
-		if (fileListedCallback) {
-			const { name, channel_name } = params;
-			savePendingPublish({
-				name: params.name,
-				channel_name: params.channel_name
-			});
-			fileListedCallback(true);
-		}
-	}, 2000);
+    if (fileListedCallback) {
+      const { name, channel_name } = params;
+      savePendingPublish({
+        name: params.name,
+        channel_name: params.channel_name,
+      });
+      fileListedCallback(true);
+    }
+  }, 2000);
 };
 
 lbry.getClientSettings = function() {
-	var outSettings = {};
-	for (let setting of Object.keys(lbry.defaultClientSettings)) {
-		var localStorageVal = localStorage.getItem('setting_' + setting);
-		outSettings[setting] = localStorageVal === null
-			? lbry.defaultClientSettings[setting]
-			: JSON.parse(localStorageVal);
-	}
-	return outSettings;
+  var outSettings = {};
+  for (let setting of Object.keys(lbry.defaultClientSettings)) {
+    var localStorageVal = localStorage.getItem("setting_" + setting);
+    outSettings[setting] = localStorageVal === null
+      ? lbry.defaultClientSettings[setting]
+      : JSON.parse(localStorageVal);
+  }
+  return outSettings;
 };
 
 lbry.getClientSetting = function(setting) {
-	var localStorageVal = localStorage.getItem('setting_' + setting);
-	if (setting == 'showDeveloperMenu') {
-		return true;
-	}
-	return localStorageVal === null
-		? lbry.defaultClientSettings[setting]
-		: JSON.parse(localStorageVal);
+  var localStorageVal = localStorage.getItem("setting_" + setting);
+  if (setting == "showDeveloperMenu") {
+    return true;
+  }
+  return localStorageVal === null
+    ? lbry.defaultClientSettings[setting]
+    : JSON.parse(localStorageVal);
 };
 
 lbry.setClientSettings = function(settings) {
-	for (let setting of Object.keys(settings)) {
-		lbry.setClientSetting(setting, settings[setting]);
-	}
+  for (let setting of Object.keys(settings)) {
+    lbry.setClientSetting(setting, settings[setting]);
+  }
 };
 
 lbry.setClientSetting = function(setting, value) {
-	return localStorage.setItem('setting_' + setting, JSON.stringify(value));
+  return localStorage.setItem("setting_" + setting, JSON.stringify(value));
 };
 
 lbry.getSessionInfo = function(callback) {
-	lbry.call('status', { session_status: true }, callback);
+  lbry.call("status", { session_status: true }, callback);
 };
 
 lbry.reportBug = function(message, callback) {
-	lbry.call(
-		'report_bug',
-		{
-			message: message
-		},
-		callback
-	);
+  lbry.call(
+    "report_bug",
+    {
+      message: message,
+    },
+    callback
+  );
 };
 
 //utilities
 lbry.formatCredits = function(amount, precision) {
-	return amount.toFixed(precision || 1).replace(/\.?0+$/, '');
+  return amount.toFixed(precision || 1).replace(/\.?0+$/, "");
 };
 
 lbry.formatName = function(name) {
-	// Converts LBRY name to standard format (all lower case, no special characters, spaces replaced by dashes)
-	name = name.replace('/s+/g', '-');
-	name = name.toLowerCase().replace(/[^a-z0-9\-]/g, '');
-	return name;
+  // Converts LBRY name to standard format (all lower case, no special characters, spaces replaced by dashes)
+  name = name.replace("/s+/g", "-");
+  name = name.toLowerCase().replace(/[^a-z0-9\-]/g, "");
+  return name;
 };
 
 lbry.imagePath = function(file) {
-	return 'img/' + file;
+  return "img/" + file;
 };
 
 lbry.getMediaType = function(contentType, fileName) {
-	if (contentType) {
-		return /^[^/]+/.exec(contentType)[0];
-	} else if (fileName) {
-		var dotIndex = fileName.lastIndexOf('.');
-		if (dotIndex == -1) {
-			return 'unknown';
-		}
+  if (contentType) {
+    return /^[^/]+/.exec(contentType)[0];
+  } else if (fileName) {
+    var dotIndex = fileName.lastIndexOf(".");
+    if (dotIndex == -1) {
+      return "unknown";
+    }
 
-		var ext = fileName.substr(dotIndex + 1);
-		if (/^mp4|mov|m4v|flv|f4v$/i.test(ext)) {
-			return 'video';
-		} else if (/^mp3|m4a|aac|wav|flac|ogg$/i.test(ext)) {
-			return 'audio';
-		} else if (/^html|htm|pdf|odf|doc|docx|md|markdown|txt$/i.test(ext)) {
-			return 'document';
-		} else {
-			return 'unknown';
-		}
-	} else {
-		return 'unknown';
-	}
+    var ext = fileName.substr(dotIndex + 1);
+    if (/^mp4|mov|m4v|flv|f4v$/i.test(ext)) {
+      return "video";
+    } else if (/^mp3|m4a|aac|wav|flac|ogg$/i.test(ext)) {
+      return "audio";
+    } else if (/^html|htm|pdf|odf|doc|docx|md|markdown|txt$/i.test(ext)) {
+      return "document";
+    } else {
+      return "unknown";
+    }
+  } else {
+    return "unknown";
+  }
 };
 
 lbry.stop = function(callback) {
-	lbry.call('stop', {}, callback);
+  lbry.call("stop", {}, callback);
 };
 
 lbry._subscribeIdCount = 0;
@@ -384,57 +384,57 @@ lbry._balanceSubscribeInterval = 5000;
 
 lbry._balanceUpdateInterval = null;
 lbry._updateBalanceSubscribers = function() {
-	lbry.wallet_balance().then(function(balance) {
-		for (let callback of Object.values(lbry._balanceSubscribeCallbacks)) {
-			callback(balance);
-		}
-	});
+  lbry.wallet_balance().then(function(balance) {
+    for (let callback of Object.values(lbry._balanceSubscribeCallbacks)) {
+      callback(balance);
+    }
+  });
 
-	if (
-		!lbry._balanceUpdateInterval &&
-		Object.keys(lbry._balanceSubscribeCallbacks).length
-	) {
-		lbry._balanceUpdateInterval = setInterval(() => {
-			lbry._updateBalanceSubscribers();
-		}, lbry._balanceSubscribeInterval);
-	}
+  if (
+    !lbry._balanceUpdateInterval &&
+    Object.keys(lbry._balanceSubscribeCallbacks).length
+  ) {
+    lbry._balanceUpdateInterval = setInterval(() => {
+      lbry._updateBalanceSubscribers();
+    }, lbry._balanceSubscribeInterval);
+  }
 };
 
 lbry.balanceSubscribe = function(callback) {
-	const subscribeId = ++lbry._subscribeIdCount;
-	lbry._balanceSubscribeCallbacks[subscribeId] = callback;
-	lbry._updateBalanceSubscribers();
-	return subscribeId;
+  const subscribeId = ++lbry._subscribeIdCount;
+  lbry._balanceSubscribeCallbacks[subscribeId] = callback;
+  lbry._updateBalanceSubscribers();
+  return subscribeId;
 };
 
 lbry.balanceUnsubscribe = function(subscribeId) {
-	delete lbry._balanceSubscribeCallbacks[subscribeId];
-	if (
-		lbry._balanceUpdateInterval &&
-		!Object.keys(lbry._balanceSubscribeCallbacks).length
-	) {
-		clearInterval(lbry._balanceUpdateInterval);
-	}
+  delete lbry._balanceSubscribeCallbacks[subscribeId];
+  if (
+    lbry._balanceUpdateInterval &&
+    !Object.keys(lbry._balanceSubscribeCallbacks).length
+  ) {
+    clearInterval(lbry._balanceUpdateInterval);
+  }
 };
 
 lbry.showMenuIfNeeded = function() {
-	const showingMenu = sessionStorage.getItem('menuShown') || null;
-	const chosenMenu = lbry.getClientSetting('showDeveloperMenu')
-		? 'developer'
-		: 'normal';
-	if (chosenMenu != showingMenu) {
-		menu.showMenubar(chosenMenu == 'developer');
-	}
-	sessionStorage.setItem('menuShown', chosenMenu);
+  const showingMenu = sessionStorage.getItem("menuShown") || null;
+  const chosenMenu = lbry.getClientSetting("showDeveloperMenu")
+    ? "developer"
+    : "normal";
+  if (chosenMenu != showingMenu) {
+    menu.showMenubar(chosenMenu == "developer");
+  }
+  sessionStorage.setItem("menuShown", chosenMenu);
 };
 
 lbry.getAppVersionInfo = function() {
-	return new Promise((resolve, reject) => {
-		ipcRenderer.once('version-info-received', (event, versionInfo) => {
-			resolve(versionInfo);
-		});
-		ipcRenderer.send('version-info-requested');
-	});
+  return new Promise((resolve, reject) => {
+    ipcRenderer.once("version-info-received", (event, versionInfo) => {
+      resolve(versionInfo);
+    });
+    ipcRenderer.send("version-info-requested");
+  });
 };
 
 /**
@@ -447,117 +447,107 @@ lbry.getAppVersionInfo = function() {
  * (If a real publish with the same name is found, the pending publish will be ignored and removed.)
  */
 lbry.file_list = function(params = {}) {
-	return new Promise((resolve, reject) => {
-		const { name, channel_name, outpoint } = params;
+  return new Promise((resolve, reject) => {
+    const { name, channel_name, outpoint } = params;
 
-		/**
+    /**
      * If we're searching by outpoint, check first to see if there's a matching pending publish.
      * Pending publishes use their own faux outpoints that are always unique, so we don't need
      * to check if there's a real file.
      */
-		if (outpoint) {
-			const pendingPublish = getPendingPublish({ outpoint });
-			if (pendingPublish) {
-				resolve([pendingPublishToDummyFileInfo(pendingPublish)]);
-				return;
-			}
-		}
+    if (outpoint) {
+      const pendingPublish = getPendingPublish({ outpoint });
+      if (pendingPublish) {
+        resolve([pendingPublishToDummyFileInfo(pendingPublish)]);
+        return;
+      }
+    }
 
-		lbry.call(
-			'file_list',
-			params,
-			fileInfos => {
-				removePendingPublishIfNeeded({ name, channel_name, outpoint });
+    lbry.call(
+      "file_list",
+      params,
+      fileInfos => {
+        removePendingPublishIfNeeded({ name, channel_name, outpoint });
 
-				const dummyFileInfos = lbry
-					.getPendingPublishes()
-					.map(pendingPublishToDummyFileInfo);
-				resolve([...fileInfos, ...dummyFileInfos]);
-			},
-			reject,
-			reject
-		);
-	});
+        const dummyFileInfos = lbry
+          .getPendingPublishes()
+          .map(pendingPublishToDummyFileInfo);
+        resolve([...fileInfos, ...dummyFileInfos]);
+      },
+      reject,
+      reject
+    );
+  });
 };
 
 lbry.claim_list_mine = function(params = {}) {
-	return new Promise((resolve, reject) => {
-		lbry.call(
-			'claim_list_mine',
-			params,
-			claims => {
-				for (let { name, channel_name, txid, nout } of claims) {
-					removePendingPublishIfNeeded({
-						name,
-						channel_name,
-						outpoint: txid + ':' + nout
-					});
-				}
+  return new Promise((resolve, reject) => {
+    lbry.call(
+      "claim_list_mine",
+      params,
+      claims => {
+        for (let { name, channel_name, txid, nout } of claims) {
+          removePendingPublishIfNeeded({
+            name,
+            channel_name,
+            outpoint: txid + ":" + nout,
+          });
+        }
 
-				const dummyClaims = lbry
-					.getPendingPublishes()
-					.map(pendingPublishToDummyClaim);
-				resolve([...claims, ...dummyClaims]);
-			},
-			reject,
-			reject
-		);
-	});
+        const dummyClaims = lbry
+          .getPendingPublishes()
+          .map(pendingPublishToDummyClaim);
+        resolve([...claims, ...dummyClaims]);
+      },
+      reject,
+      reject
+    );
+  });
 };
 
-const claimCacheKey = 'resolve_claim_cache';
-lbry._claimCache = getSession(claimCacheKey, {});
 lbry._resolveXhrs = {};
 lbry.resolve = function(params = {}) {
-	return new Promise((resolve, reject) => {
-		if (!params.uri) {
-			throw __('Resolve has hacked cache on top of it that requires a URI');
-		}
-		if (params.uri && lbry._claimCache[params.uri] !== undefined) {
-			resolve(lbry._claimCache[params.uri]);
-		} else {
-			lbry._resolveXhrs[params.uri] = lbry.call(
-				'resolve',
-				params,
-				function(data) {
-					if (data !== undefined) {
-						lbry._claimCache[params.uri] = data;
-					}
-					setSession(claimCacheKey, lbry._claimCache);
-					resolve(data);
-				},
-				reject
-			);
-		}
-	});
+  return new Promise((resolve, reject) => {
+    if (!params.uri) {
+      throw __("Resolve has hacked cache on top of it that requires a URI");
+    }
+    lbry._resolveXhrs[params.uri] = lbry.call(
+      "resolve",
+      params,
+      function(data) {
+        resolve(data);
+      },
+      reject
+    );
+  });
 };
 
 lbry.cancelResolve = function(params = {}) {
-	const xhr = lbry._resolveXhrs[params.uri];
-	if (xhr && xhr.readyState > 0 && xhr.readyState < 4) {
-		xhr.abort();
-	}
+  const xhr = lbry._resolveXhrs[params.uri];
+  if (xhr && xhr.readyState > 0 && xhr.readyState < 4) {
+    xhr.abort();
+  }
 };
 
 lbry = new Proxy(lbry, {
-	get: function(target, name) {
-		if (name in target) {
-			return target[name];
-		}
+  get: function(target, name) {
+    if (name in target) {
+      return target[name];
+    }
 
-		return function(params = {}) {
-			return new Promise((resolve, reject) => {
-				jsonrpc.call(
-					lbry.daemonConnectionString,
-					name,
-					params,
-					resolve,
-					reject,
-					reject
-				);
-			});
-		};
-	}
+    return function(params = {}) {
+      return new Promise((resolve, reject) => {
+        jsonrpc.call(
+          lbry.daemonConnectionString,
+          name,
+          params,
+          resolve,
+          reject,
+          reject
+        );
+      });
+    };
+  },
 });
 
 export default lbry;

--- a/ui/js/page/fileListDownloaded/view.jsx
+++ b/ui/js/page/fileListDownloaded/view.jsx
@@ -12,7 +12,7 @@ import SubHeader from "component/subHeader";
 
 class FileListDownloaded extends React.PureComponent {
   componentWillMount() {
-    this.props.fetchFileInfosDownloaded();
+    if (!this.props.isPending) this.props.fetchFileInfosDownloaded();
   }
 
   render() {

--- a/ui/js/page/fileListPublished/view.jsx
+++ b/ui/js/page/fileListPublished/view.jsx
@@ -12,7 +12,7 @@ import SubHeader from "component/subHeader";
 
 class FileListPublished extends React.PureComponent {
   componentWillMount() {
-    this.props.fetchFileListPublished();
+    if (!this.props.isPending) this.props.fetchFileListPublished();
   }
 
   componentDidUpdate() {


### PR DESCRIPTION
This fixes published files not appearing until restart

- Always refresh the claim list when loading published/downloaded pages.
- Remove caching happening inside of `lbry.js` (this is what stops the URI ever being solved again until restart)