### PR TITLE
Make URLs load correctly after clicking a lbry:// link with the app closed

### DIFF
--- a/ui/js/actions/app.js
+++ b/ui/js/actions/app.js
@@ -225,7 +225,6 @@ export function doDaemonReady() {
     dispatch({
       type: types.DAEMON_READY,
     });
-    dispatch(doChangePath("/discover"));
     dispatch(doFetchDaemonSettings());
     dispatch(doFileList());
   };


### PR DESCRIPTION
We were loading the Discover page at the end of the launch screen. That meant that if a user started with LBRY closed and started it by clicking on a lbry:// link, it would load during the launch screen but then get overridden by the Discover page as soon as the launch screen finished.

Fortunately, this load was redundant anyway as the necessary state is already being set in the default state for the App component:
https://github.com/lbryio/lbry-app/blob/902fb96878c175d480be9ed11207a21bedd61713/ui/js/reducers/app.js#L7