### PR TITLE
Fix links from transactions to block explorer

### DIFF
--- a/ui/js/component/transactionList/view.jsx
+++ b/ui/js/component/transactionList/view.jsx
@@ -28,7 +28,7 @@ class TransactionList extends React.PureComponent {
             <td>
               <a
                 className="button-text"
-                href={"https://explorer.lbry.io/#!/transaction?id=" + item.id}
+                href={"https://explorer.lbry.io/#!/transaction/" + item.id}
               >
                 {item.id.substr(0, 7)}
               </a>


### PR DESCRIPTION
Looks like URLs changed slightly with the new block explorer.