### PR TITLE
Add claim ids to urls in downloaded/published files

### DIFF
--- a/ui/js/component/fileList/view.jsx
+++ b/ui/js/component/fileList/view.jsx
@@ -70,7 +70,9 @@ class FileList extends React.PureComponent {
       const uri = lbryuri.build({
         contentName: fileInfo.name,
         channelName: fileInfo.channel_name,
+        claimId: fileInfo.claim_id,
       });
+
       content.push(
         <FileTile
           key={uri}


### PR DESCRIPTION
Not sure if this is what is required here? Added the claim ID to the URIs in file lists. This way, when you click through to the show page, the URI in the wunderbar is now the full version which can be copied and distributed.

![2017-06-23 at 13 38](https://user-images.githubusercontent.com/20863631/27470051-4a1061dc-581c-11e7-98dc-e9c378055a60.jpg)
