### PR TITLE
Allow max_key_fee to be set (WIP)

### DIFF
--- a/ui/js/page/settings/view.jsx
+++ b/ui/js/page/settings/view.jsx
@@ -85,6 +85,15 @@ class SettingsPage extends React.PureComponent {
     this.props.setClientSetting("showNsfw", event.target.checked);
   }
 
+  onMaxKeyFeeAmountFieldChange(event) {
+    const value = event.target.value;
+    if (value === "") return;
+
+    const max_key_fee = parseFloat(value);
+
+    this.setDaemonSetting("max_key_fee", max_key_fee);
+  }
+
   // onLanguageChange(language) {
   //   lbry.setClientSetting('language', language);
   //   i18n.setLocale(language);
@@ -274,6 +283,58 @@ class SettingsPage extends React.PureComponent {
                 "NSFW content may include nudity, intense sexuality, profanity, or other adult content. By displaying NSFW content, you are affirming you are of legal age to view mature content in your country or jurisdiction.  "
               )}
             />
+          </div>
+        </section>
+
+        <section className="card">
+          <div className="card__content">
+            <h3>{__("Language")}</h3>
+          </div>
+          <div className="card__content">
+            <div className="form-row">
+              <FormField
+                type="radio"
+                name="language"
+                label={__("English")}
+                onChange={() => {
+                  this.onLanguageChange("en");
+                }}
+                defaultChecked={this.state.language == "en"}
+              />
+            </div>
+            <div className="form-row">
+              <FormField
+                type="radio"
+                name="language"
+                label="Serbian"
+                onChange={() => {
+                  this.onLanguageChange("rs");
+                }}
+                defaultChecked={this.state.language == "rs"}
+              />
+            </div>
+          </div>
+        </section>
+
+        <section className="card">
+          <div className="card__content">
+            <h3>{__("Max Fee")}</h3>
+          </div>
+          <div className="card__content">
+            {daemonSettings &&
+              daemonSettings.max_key_fee &&
+              <FormRow
+                type="number"
+                min="0"
+                step="1"
+                defaultValue={daemonSettings.max_key_fee}
+                placeholder="10"
+                className="form-field__input--inline"
+                onChange={this.onMaxKeyFeeAmountFieldChange.bind(this)}
+                helper={__(
+                  "This allows you to set your maximum download fee. It will prevent you from downloading any files where the fee is higher than this amount."
+                )}
+              />}
           </div>
         </section>
 


### PR DESCRIPTION
@kauffj  I think something is not right with this one. When I first checked my daemon settings the max_key_fee looked something like this:

```
{
  "address": "",
  "amount": 25,
  "currency": "USD"
}
```

The API documentation says that `settings_set` takes a `max_key_fee` arg of type `Float`. Now that I passed it one (`26.5`) the max_key_fee on my daemon is simply returning that number instead of an object with address and currency.

Also, it's not possible to pass a string or integer to this set method. This is a problem as javascript can't distinguish between `25` and `25.0`, so it passes an integer and the daemon blows up with `808 ERROR    lbrynet.lbrynet_daemon.auth.server:346: Failed to process settings_set: object of type 'int' has no len()`