### PR TITLE
Don't call history.back when there is no previous history

### DIFF
--- a/ui/js/actions/app.js
+++ b/ui/js/actions/app.js
@@ -61,6 +61,8 @@ export function doChangePath(path) {
 
 export function doHistoryBack() {
   return function(dispatch, getState) {
+    if (!history.state) return;
+
     history.back();
   };
 }


### PR DESCRIPTION
Without this the app does a full refresh sometimes when you keep clicking back.