### PR TITLE
Teardown old window event listeners and don't blow up when window isn't focused

### DIFF
--- a/ui/js/main.js
+++ b/ui/js/main.js
@@ -75,7 +75,10 @@ document.addEventListener("click", event => {
 
 const application = remote.app;
 const dock = application.dock;
-const win = remote.BrowserWindow.getFocusedWindow();
+const win = remote.getCurrentWindow();
+
+// Tear down previous event listeners when reload
+win.removeAllListeners();
 
 // Clear the badge when the window is focused
 win.on("focus", () => {


### PR DESCRIPTION
Currently the app blows up if the window isn't focused as it loads or during a refresh. Also, old focused listeners are left around and pollute the logs with errors.