### PR TITLE
Issue #310 video volume reset fix

### DIFF
--- a/ui/js/component/video/internal/player.jsx
+++ b/ui/js/component/video/internal/player.jsx
@@ -42,7 +42,16 @@ class VideoPlayer extends React.PureComponent {
           once: true,
         }
       );
+      mediaElement.addEventListener("volumechange", () => {
+        localStorage.setItem("prefs_volume", mediaElement.volume);
+      });
+      mediaElement.volume = this.getPreferredVolume();
     }
+  }
+
+  getPreferredVolume() {
+    const volumePreference = parseFloat(localStorage.getItem("prefs_volume"));
+    return isNaN(volumePreference) ? 1 : volumePreference;
   }
 
   componentDidUpdate() {


### PR DESCRIPTION
- Media player volume is persisted to local storage when the volume is changed by the user.
- The volume from local storage will be set as the media player start volume whenever the user tries to watch a new video. It defaults to the max volume if an invalid value was retrieved from local storage.