### PR TITLE
Issue #308 hide menu in fullscreen mode on Windows

### DIFF
--- a/ui/js/component/video/internal/player.jsx
+++ b/ui/js/component/video/internal/player.jsx
@@ -1,3 +1,4 @@
+const { remote } = require("electron");
 import React from "react";
 import { Thumbnail } from "component/common";
 import player from "render-media";
@@ -25,6 +26,15 @@ class VideoPlayer extends React.PureComponent {
     const renderMediaCallback = err => {
       if (err) this.setState({ unplayable: true });
     };
+    // Handle fullscreen change for the Windows platform
+    const win32FullScreenChange = e => {
+      const win = remote.BrowserWindow.getFocusedWindow();
+      if ("win32" === process.platform) {
+        win.setMenu(
+          document.webkitIsFullScreen ? null : remote.Menu.getApplicationMenu()
+        );
+      }
+    };
 
     player.append(
       this.file(),
@@ -41,6 +51,10 @@ class VideoPlayer extends React.PureComponent {
         {
           once: true,
         }
+      );
+      mediaElement.addEventListener(
+        "webkitfullscreenchange",
+        win32FullScreenChange.bind(this)
       );
     }
   }


### PR DESCRIPTION
This hides the menu when a video enters full screen mode on Windows. I added the win32 platform check in the `webkitfullscreenchange` event handler since I was unable to reproduce the issue on Linux (Ubuntu 16.04), so I assumed it's probably Windows-specific.