### PR TITLE
Issue #255 purchase dialog confirmation content fix

### DIFF
--- a/ui/js/component/fileActions/view.jsx
+++ b/ui/js/component/fileActions/view.jsx
@@ -50,6 +50,7 @@ class FileActions extends React.PureComponent {
 
   render() {
     const {
+      mediaTitle,
       fileInfo,
       isAvailable,
       platform,
@@ -72,7 +73,7 @@ class FileActions extends React.PureComponent {
         ? __("Open in Finder")
         : __("Open in Folder"),
       showMenu = fileInfo && Object.keys(fileInfo).length > 0,
-      title = metadata ? metadata.title : uri;
+      title = mediaTitle ? mediaTitle : metadata ? metadata.title : uri;
 
     let content;
 

--- a/ui/js/page/filePage/view.jsx
+++ b/ui/js/page/filePage/view.jsx
@@ -115,7 +115,7 @@ class FilePage extends React.PureComponent {
                   : uriIndicator}
               </div>
               <div className="card__actions">
-                <FileActions uri={uri} />
+                <FileActions mediaTitle={title} uri={uri} />
               </div>
             </div>
             <div className="card__content card__subtext card__subtext card__subtext--allow-newlines">

--- a/ui/scss/component/_modal.scss
+++ b/ui/scss/component/_modal.scss
@@ -31,6 +31,8 @@
   padding: $spacing-vertical;
   box-shadow: $box-shadow-layer;
   max-width: 400px;
+
+  word-break: break-word
 }
 
 .modal__header {


### PR DESCRIPTION
- Added the `word-break: break-word` CSS style to the modal dialog to force break long overflowing text or URLs.
- Added a property called `mediaTitle` to the `FileActions` component so that the purchase confirmation dialog can display the title in cases where the `fileInfo` property or `fileInfo.metadata` may not be set.