### PR TITLE
Issue #333 media switch fix

### DIFF
--- a/ui/js/component/video/view.jsx
+++ b/ui/js/component/video/view.jsx
@@ -14,6 +14,13 @@ class Video extends React.PureComponent {
     };
   }
 
+  componentWillReceiveProps(nextProps) {
+    // reset playing state upon change path action
+    if (this.state.isPlaying) {
+      this.state.isPlaying = false;
+    }
+  }
+
   startPlaying() {
     this.setState({
       isPlaying: true,

--- a/ui/js/component/video/view.jsx
+++ b/ui/js/component/video/view.jsx
@@ -16,9 +16,17 @@ class Video extends React.PureComponent {
 
   componentWillReceiveProps(nextProps) {
     // reset playing state upon change path action
-    if (this.state.isPlaying) {
+    if (!this.isMediaSame(nextProps) && this.state.isPlaying) {
       this.state.isPlaying = false;
     }
+  }
+
+  isMediaSame(nextProps) {
+    return (
+      this.props.fileInfo &&
+      nextProps.fileInfo &&
+      this.props.fileInfo.outpoint === nextProps.fileInfo.outpoint
+    );
   }
 
   startPlaying() {


### PR DESCRIPTION
Fix for switching between audio and video media types after playback has started.

I had to set the state's `isPlaying` property directly in the `componentWillReceiveProps` method, since I tried to make use of `setState` which resulted in a no-op error: `Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op.`