### PR TITLE
A quick fix for oscuring cards for nsfw content.

### DIFF
--- a/ui/js/page/filePage/index.js
+++ b/ui/js/page/filePage/index.js
@@ -25,7 +25,7 @@ const makeSelect = () => {
     contentType: selectContentType(state, props),
     costInfo: selectCostInfo(state, props),
     metadata: selectMetadata(state, props),
-    showNsfw: !selectShowNsfw(state),
+    obscureNsfw: !selectShowNsfw(state),
     fileInfo: selectFileInfo(state, props),
   });
 


### PR DESCRIPTION
The download cards in page were not obscured when opening a link
directly(e.g. lbry://jacki2).