### PR TITLE
Track downloading files by outpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Web UI version numbers should always match the corresponding version of LBRY App
   * Restored feedback on claim amounts
   * Fixed hiding price input when Free is checked on publish form
   * Fixed hiding new identity fields on publish form
+  * Fixed files on downloaded tab not showing download progress
+  * Fixed downloading files that are deleted not being removed from the downloading list
+  * Fixed download progress bar not being cleared when a downloading file is deleted
 
 ### Deprecated
   *

--- a/ui/js/actions/content.js
+++ b/ui/js/actions/content.js
@@ -5,7 +5,7 @@ import lbryuri from "lbryuri";
 import { selectBalance } from "selectors/wallet";
 import {
   selectFileInfoForUri,
-  selectUrisDownloading,
+  selectDownloadingByOutpoint,
 } from "selectors/file_info";
 import { selectResolvingUris } from "selectors/content";
 import { selectCostInfoForUri } from "selectors/cost_info";
@@ -265,8 +265,9 @@ export function doPurchaseUri(uri, purchaseModalName) {
     const state = getState();
     const balance = selectBalance(state);
     const fileInfo = selectFileInfoForUri(state, { uri });
-    const downloadingByUri = selectUrisDownloading(state);
-    const alreadyDownloading = !!downloadingByUri[uri];
+    const downloadingByOutpoint = selectDownloadingByOutpoint(state);
+    const alreadyDownloading =
+      fileInfo && !!downloadingByOutpoint[fileInfo.outpoint];
 
     // we already fully downloaded the file.
     if (fileInfo && fileInfo.completed) {

--- a/ui/js/actions/file_info.js
+++ b/ui/js/actions/file_info.js
@@ -10,8 +10,11 @@ import {
   selectIsFetchingFileList,
   selectFileInfosByOutpoint,
   selectUrisLoading,
+  selectTotalDownloadProgress,
 } from "selectors/file_info";
-import { doCloseModal } from "actions/app";
+import { doCloseModal, doHistoryBack } from "actions/app";
+import setProgressBar from "util/setProgressBar";
+import batchActions from "util/batchActions";
 
 const { shell } = require("electron");
 
@@ -119,7 +122,22 @@ export function doDeleteFile(outpoint, deleteFromComputer, abandonClaim) {
       },
     });
 
-    dispatch(doCloseModal());
+    const totalProgress = selectTotalDownloadProgress(getState());
+    setProgressBar(totalProgress);
+  };
+}
+
+export function doDeleteFileAndGoBack(
+  fileInfo,
+  deleteFromComputer,
+  abandonClaim
+) {
+  return function(dispatch, getState) {
+    const actions = [];
+    actions.push(doCloseModal());
+    actions.push(doHistoryBack());
+    actions.push(doDeleteFile(fileInfo, deleteFromComputer, abandonClaim));
+    dispatch(batchActions(...actions));
   };
 }
 

--- a/ui/js/component/modalRemoveFile/index.js
+++ b/ui/js/component/modalRemoveFile/index.js
@@ -1,8 +1,9 @@
 import React from "react";
 import { connect } from "react-redux";
 import { doCloseModal, doHistoryBack } from "actions/app";
-import { doDeleteFile } from "actions/file_info";
+import { doDeleteFileAndGoBack } from "actions/file_info";
 import { makeSelectClaimForUriIsMine } from "selectors/claims";
+import batchActions from "util/batchActions";
 
 import ModalRemoveFile from "./view";
 
@@ -19,8 +20,7 @@ const makeSelect = () => {
 const perform = dispatch => ({
   closeModal: () => dispatch(doCloseModal()),
   deleteFile: (fileInfo, deleteFromComputer, abandonClaim) => {
-    dispatch(doHistoryBack());
-    dispatch(doDeleteFile(fileInfo, deleteFromComputer, abandonClaim));
+    dispatch(doDeleteFileAndGoBack(fileInfo, deleteFromComputer, abandonClaim));
   },
 });
 

--- a/ui/js/reducers/file_info.js
+++ b/ui/js/reducers/file_info.js
@@ -58,15 +58,15 @@ reducers[types.DOWNLOADING_STARTED] = function(state, action) {
   const { uri, outpoint, fileInfo } = action.data;
 
   const newByOutpoint = Object.assign({}, state.byOutpoint);
-  const newDownloading = Object.assign({}, state.urisDownloading);
+  const newDownloading = Object.assign({}, state.downloadingByOutpoin);
   const newLoading = Object.assign({}, state.urisLoading);
 
-  newDownloading[uri] = true;
+  newDownloading[outpoint] = true;
   newByOutpoint[outpoint] = fileInfo;
   delete newLoading[uri];
 
   return Object.assign({}, state, {
-    urisDownloading: newDownloading,
+    downloadingByOutpoint: newDownloading,
     urisLoading: newLoading,
     byOutpoint: newByOutpoint,
   });
@@ -76,14 +76,14 @@ reducers[types.DOWNLOADING_PROGRESSED] = function(state, action) {
   const { uri, outpoint, fileInfo } = action.data;
 
   const newByOutpoint = Object.assign({}, state.byOutpoint);
-  const newDownloading = Object.assign({}, state.urisDownloading);
+  const newDownloading = Object.assign({}, state.downloadingByOutpoint);
 
   newByOutpoint[outpoint] = fileInfo;
-  newDownloading[uri] = true;
+  newDownloading[outpoint] = true;
 
   return Object.assign({}, state, {
     byOutpoint: newByOutpoint,
-    urisDownloading: newDownloading,
+    downloadingByOutpoint: newDownloading,
   });
 };
 
@@ -91,14 +91,14 @@ reducers[types.DOWNLOADING_COMPLETED] = function(state, action) {
   const { uri, outpoint, fileInfo } = action.data;
 
   const newByOutpoint = Object.assign({}, state.byOutpoint);
-  const newDownloading = Object.assign({}, state.urisDownloading);
+  const newDownloading = Object.assign({}, state.downloadingByOutpoint);
 
   newByOutpoint[outpoint] = fileInfo;
-  delete newDownloading[uri];
+  delete newDownloading[outpoint];
 
   return Object.assign({}, state, {
     byOutpoint: newByOutpoint,
-    urisDownloading: newDownloading,
+    downloadingByOutpoint: newDownloading,
   });
 };
 

--- a/ui/js/reducers/file_info.js
+++ b/ui/js/reducers/file_info.js
@@ -106,11 +106,14 @@ reducers[types.FILE_DELETE] = function(state, action) {
   const { outpoint } = action.data;
 
   const newByOutpoint = Object.assign({}, state.byOutpoint);
+  const downloadingByOutpoint = Object.assign({}, state.downloadingByOutpoint);
 
   delete newByOutpoint[outpoint];
+  delete downloadingByOutpoint[outpoint];
 
   return Object.assign({}, state, {
     byOutpoint: newByOutpoint,
+    downloadingByOutpoint,
   });
 };
 

--- a/ui/js/selectors/file_info.js
+++ b/ui/js/selectors/file_info.js
@@ -39,14 +39,18 @@ export const makeSelectFileInfoForUri = () => {
   return createSelector(selectFileInfoForUri, fileInfo => fileInfo);
 };
 
-export const selectUrisDownloading = createSelector(
+export const selectDownloadingByOutpoint = createSelector(
   _selectState,
-  state => state.urisDownloading || {}
+  state => state.downloadingByOutpoint || {}
 );
 
 const selectDownloadingForUri = (state, props) => {
-  const byUri = selectUrisDownloading(state);
-  return byUri[props.uri];
+  const byOutpoint = selectDownloadingByOutpoint(state);
+  const fileInfo = selectFileInfoForUri(state, props);
+
+  if (!fileInfo) return false;
+
+  return byOutpoint[fileInfo.outpoint];
 };
 
 export const makeSelectDownloadingForUri = () => {
@@ -135,14 +139,14 @@ export const selectFileInfosByUri = createSelector(
 );
 
 export const selectDownloadingFileInfos = createSelector(
-  selectUrisDownloading,
-  selectFileInfosByUri,
-  (urisDownloading, byUri) => {
-    const uris = Object.keys(urisDownloading);
+  selectDownloadingByOutpoint,
+  selectFileInfosByOutpoint,
+  (downloadingByOutpoint, fileInfosByOutpoint) => {
+    const outpoints = Object.keys(downloadingByOutpoint);
     const fileInfos = [];
 
-    uris.forEach(uri => {
-      const fileInfo = byUri[uri];
+    outpoints.forEach(outpoint => {
+      const fileInfo = fileInfosByOutpoint[outpoint];
 
       if (fileInfo) fileInfos.push(fileInfo);
     });


### PR DESCRIPTION
Now we have one unique place to track downloading files, instead of by URI. This fixes files in the downloaded file list not showing download progress along with some other downloading weirdness.