### PR TITLE
Display the download button for files that are not downloading and have 0 progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Web UI version numbers should always match the corresponding version of LBRY App
   * Fixed files on downloaded tab not showing download progress
   * Fixed downloading files that are deleted not being removed from the downloading list
   * Fixed download progress bar not being cleared when a downloading file is deleted
+  * Fixed app thinking downloads with 0 progress were downloaded after restart
 
 ### Deprecated
   *

--- a/ui/js/component/fileActions/view.jsx
+++ b/ui/js/component/fileActions/view.jsx
@@ -118,7 +118,10 @@ class FileActions extends React.PureComponent {
           />
         </div>
       );
-    } else if (fileInfo === null && !downloading) {
+    } else if (
+      (fileInfo === null || (fileInfo && fileInfo.written_bytes === 0)) &&
+      !downloading
+    ) {
       if (!costInfo) {
         content = <BusyMessage message={__("Fetching cost info")} />;
       } else {


### PR DESCRIPTION
Seems to be a problem where some files start to download but never receive any data. Then the "open" link appears when viewing them after the app has been restarted. This switches it to display the download link still.