### PR TITLE
Restart download monitoring in redux for pending downloads after restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Web UI version numbers should always match the corresponding version of LBRY App
   * Fixed downloading files that are deleted not being removed from the downloading list
   * Fixed download progress bar not being cleared when a downloading file is deleted
   * Fixed refresh regression after adding scroll position to history state
-  * Fixed app thinking downloads with 0 progress were downloaded after restart
+  * Fixed app not monitoring download progress on files in progress between restarts
 
 ### Deprecated
   *
@@ -41,7 +41,7 @@ Web UI version numbers should always match the corresponding version of LBRY App
 
 ### Removed
   * Removed bandwidth caps from settings, because the daemon was not respecting them anyway.
-  * 
+  *
 
 ## [0.13.0] - 2017-06-30
 

--- a/ui/js/component/fileActions/index.js
+++ b/ui/js/component/fileActions/index.js
@@ -13,7 +13,7 @@ import { doCloseModal, doOpenModal } from "actions/app";
 import { doFetchAvailability } from "actions/availability";
 import { doOpenFileInShell, doOpenFileInFolder } from "actions/file_info";
 import { makeSelectClaimForUriIsMine } from "selectors/claims";
-import { doPurchaseUri, doLoadVideo } from "actions/content";
+import { doPurchaseUri, doLoadVideo, doStartDownload } from "actions/content";
 import FileActions from "./view";
 
 const makeSelect = () => {
@@ -47,6 +47,7 @@ const perform = dispatch => ({
   openModal: modal => dispatch(doOpenModal(modal)),
   startDownload: uri => dispatch(doPurchaseUri(uri, "affirmPurchase")),
   loadVideo: uri => dispatch(doLoadVideo(uri)),
+  restartDownload: (uri, outpoint) => dispatch(doStartDownload(uri, outpoint)),
 });
 
 export default connect(makeSelect, perform)(FileActions);

--- a/ui/js/component/fileActions/view.jsx
+++ b/ui/js/component/fileActions/view.jsx
@@ -22,6 +22,20 @@ class FileActions extends React.PureComponent {
 
   componentWillReceiveProps(nextProps) {
     this.checkAvailability(nextProps.uri);
+    this.restartDownload(nextProps);
+  }
+
+  restartDownload(props) {
+    const { downloading, fileInfo, uri, restartDownload } = props;
+
+    if (
+      !downloading &&
+      fileInfo &&
+      !fileInfo.written_bytes &&
+      fileInfo.written_bytes < fileInfo.total_bytes
+    ) {
+      restartDownload(uri, fileInfo.outpoint);
+    }
   }
 
   checkAvailability(uri) {
@@ -118,10 +132,7 @@ class FileActions extends React.PureComponent {
           />
         </div>
       );
-    } else if (
-      (fileInfo === null || (fileInfo && fileInfo.written_bytes === 0)) &&
-      !downloading
-    ) {
+    } else if (fileInfo === null && !downloading) {
       if (!costInfo) {
         content = <BusyMessage message={__("Fetching cost info")} />;
       } else {


### PR DESCRIPTION
A better download fix. Now the app will start monitoring downloads again between restarts.