### PR TITLE
Quick fix to stop an infinite loop

### DIFF
--- a/ui/js/component/fileActions/view.jsx
+++ b/ui/js/component/fileActions/view.jsx
@@ -31,7 +31,8 @@ class FileActions extends React.PureComponent {
     if (
       !downloading &&
       fileInfo &&
-      !fileInfo.written_bytes &&
+      !fileInfo.completed &&
+      fileInfo.written_bytes !== false &&
       fileInfo.written_bytes < fileInfo.total_bytes
     ) {
       restartDownload(uri, fileInfo.outpoint);


### PR DESCRIPTION
Will move restart download to callback after file_list when I get some more time.