### PR TITLE
Issue #255 purchase confirmation dialog css fix

### DIFF
--- a/ui/scss/component/_modal.scss
+++ b/ui/scss/component/_modal.scss
@@ -31,6 +31,8 @@
   padding: $spacing-vertical;
   box-shadow: $box-shadow-layer;
   max-width: 400px;
+
+  word-break: break-word
 }
 
 .modal__header {

--- a/ui/scss/component/_modal.scss
+++ b/ui/scss/component/_modal.scss
@@ -32,7 +32,7 @@
   box-shadow: $box-shadow-layer;
   max-width: 400px;
 
-  word-break: break-word
+  word-break: break-word;
 }
 
 .modal__header {


### PR DESCRIPTION
@kauffj `word-break: break-word` is Webkit-specific which gracefully handles long overflowing text and doesn't split regular words in the middle like `break-all` does. You can refer to https://miketaylr.com/posts/2014/01/word-break-break-word.html for more details about this property.