### PR TITLE
(quickfix) Now displays two buttons in IncompatibleDaemonModal.

### DIFF
--- a/ui/js/actions/app.js
+++ b/ui/js/actions/app.js
@@ -297,7 +297,13 @@ export function doClearCache() {
   };
 }
 
-export function doQuitAndLaunchDaemonHelp() {
+export function doQuit() {
+  return function(dispatch, getState) {
+    remote.app.quit();
+  };
+}
+
+export function doLaunchDaemonHelp() {
   return function(dispatch, getState) {
     shell.openExternal("https://lbry.io/faq/incompatible-protocol-version");
     remote.app.quit();

--- a/ui/js/component/modalIncompatibleDaemon/index.jsx
+++ b/ui/js/component/modalIncompatibleDaemon/index.jsx
@@ -1,13 +1,14 @@
 import React from "react";
 import { connect } from "react-redux";
 import { doQuit, doSkipWrongDaemonNotice } from "actions/app";
-import { doQuitAndLaunchDaemonHelp } from "actions/app";
+import { doLaunchDaemonHelp } from "actions/app";
 import ModalIncompatibleDaemon from "./view";
 
 const select = state => ({});
 
 const perform = dispatch => ({
-  quitAndLaunchDaemonHelp: () => dispatch(doQuitAndLaunchDaemonHelp()),
+  quit: () => dispatch(doQuit()),
+  launchDaemonHelp: () => dispatch(doLaunchDaemonHelp()),
 });
 
 export default connect(select, perform)(ModalIncompatibleDaemon);

--- a/ui/js/component/modalIncompatibleDaemon/view.jsx
+++ b/ui/js/component/modalIncompatibleDaemon/view.jsx
@@ -3,15 +3,17 @@ import { Modal } from "component/modal";
 
 class ModalIncompatibleDaemon extends React.PureComponent {
   render() {
-    const { quitAndLaunchDaemonHelp } = this.props;
+    const { quit, launchDaemonHelp } = this.props;
 
     return (
       <Modal
         isOpen={true}
         contentLabel={__("Incompatible daemon running")}
-        type="alert"
-        confirmButtonLabel={__("Quit and Learn More")}
-        onConfirmed={quitAndLaunchDaemonHelp}
+        type="confirm"
+        confirmButtonLabel={__("Quit")}
+        onConfirmed={quit}
+        abortButtonLabel={__("Learn More")}
+        onAborted={launchDaemonHelp}
       >
         {__(
           "This browser is running with an incompatible version of the LBRY protocol and your install must be repaired."


### PR DESCRIPTION
The quit and learn more buttons are now displayed separately. This is helpful in case you just want to quit the app without opening the webpage.