### PR TITLE
Set window title to filePage metadata title

### DIFF
--- a/ui/js/page/filePage/view.jsx
+++ b/ui/js/page/filePage/view.jsx
@@ -36,6 +36,9 @@ class FilePage extends React.PureComponent {
   componentDidMount() {
     this.fetchFileInfo(this.props);
     this.fetchCostInfo(this.props);
+    document.title = this.props.metadata
+      ? this.props.metadata.title
+      : document.title;
   }
 
   componentWillReceiveProps(nextProps) {
@@ -111,7 +114,7 @@ class FilePage extends React.PureComponent {
               {!fileInfo || fileInfo.written_bytes <= 0
                 ? <span style={{ float: "right" }}>
                     <FilePrice uri={lbryuri.normalize(uri)} />
-                    {isRewardContent && <span>{" "}<IconFeatured /></span> }
+                    {isRewardContent && <span>{" "}<IconFeatured /></span>}
                   </span>
                 : null}
               <h1>{title}</h1>


### PR DESCRIPTION
Currently, the window title is set to the item's lbry URL after opening a media item. This updates the title in the `componentDidMount` method if metadata is present.