### PR TITLE
Fix for blurry text and image on hover

### DIFF
--- a/ui/scss/component/_card.scss
+++ b/ui/scss/component/_card.scss
@@ -92,7 +92,6 @@ $card-link-scaling: 1.1;
 }
 .card--link {
   transition: transform 120ms ease-in-out;
-  backface-visibility: visible
 }
 .card--link:hover {
   position: relative;

--- a/ui/scss/component/_card.scss
+++ b/ui/scss/component/_card.scss
@@ -97,7 +97,7 @@ $card-link-scaling: 1.1;
   position: relative;
   z-index: 1;
   box-shadow: $box-shadow-focus;
-  transform: scale($card-link-scaling) translate3d($translate-card-hover, 0, 0);
+  transform: scale($card-link-scaling) translateX($translate-card-hover);
   transform-origin: 50% 50%;
   overflow-x: visible;
   overflow-y: visible

--- a/ui/scss/component/_card.scss
+++ b/ui/scss/component/_card.scss
@@ -92,6 +92,7 @@ $card-link-scaling: 1.1;
 }
 .card--link {
   transition: transform 120ms ease-in-out;
+  backface-visibility: visible
 }
 .card--link:hover {
   position: relative;
@@ -103,7 +104,7 @@ $card-link-scaling: 1.1;
   overflow-y: visible
 }
 .card--link:hover ~ .card--link {
-  transform: translate3d($translate-card-hover * 2, 0, 0);
+  transform: translateX($translate-card-hover * 2);
 }
 
 .card__media {


### PR DESCRIPTION
Replaced translate3d with translateX in CSS since the cards only need to shift on the x-axis (horizontally). More details at https://stackoverflow.com/questions/8024061/webkit-blurry-text-with-css-scale-translate3d.