### PR TITLE
Fix video width

### DIFF
--- a/ui/scss/component/_video.scss
+++ b/ui/scss/component/_video.scss
@@ -21,6 +21,9 @@ video {
   video {
     height: 100%;
     width: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
   }
   &.video--hidden {
     height: $height-video-embedded;

--- a/ui/scss/component/_video.scss
+++ b/ui/scss/component/_video.scss
@@ -20,9 +20,7 @@ video {
   position: relative;
   video {
     height: 100%;
-    position: absolute;
-    left: 0;
-    top: 0;
+    width: 100%;
   }
   &.video--hidden {
     height: $height-video-embedded;


### PR DESCRIPTION
![how_to_fix_video_aligment](https://user-images.githubusercontent.com/14793624/29102948-e2a2330e-7c79-11e7-9dbe-6991f3e2cf50.gif)

The real problem is not the alignment but the the width of the `video` element. 
~Since it's using a container there is no need for `position: absolute`,~
setting the width to `100% `  should do the trick :smile: 

### Fixes
Fix: https://github.com/lbryio/lbry-app/issues/419
Prevent regression:  #295


