### PR TITLE
Fix build and release system to store all daemon version settings in app/package.json

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -20,6 +20,7 @@
     "electron-rebuild": "^1.5.11"
   },
   "lbrySettings": {
-    "lbrynetDaemonVersion": "0.14.2"
+    "lbrynetDaemonVersion": "0.14.2",
+    "lbrynetDaemonUrlTemplate": "https://github.com/lbryio/lbry/releases/download/vDAEMONVER/lbrynet-daemon-vDAEMONVER-OSNAME.zip"
   }
 }

--- a/build/DAEMON_URL
+++ b/build/DAEMON_URL
@@ -1,1 +1,0 @@
-https://github.com/lbryio/lbry/releases/download/v0.14.2/lbrynet-daemon-v0.14.2-OSNAME.zip

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -29,7 +29,10 @@ cd ..
 
 
 # get daemon and cli executable
-$daemon_url = (Get-Content build\DAEMON_URL -Raw).replace("OSNAME", "windows")
+$package_settings = (Get-Content app\package.json -Raw | ConvertFrom-Json).lbrySettings
+$daemon_ver = $package_settings.lbrynetDaemonVersion
+$daemon_url_template = $package_settings.lbrynetDaemonUrlTemplate
+$daemon_url = $daemon_url_template.Replace('OSNAME', 'windows').Replace('DAEMONVER', $daemon_ver)
 Invoke-WebRequest -Uri $daemon_url -OutFile daemon.zip
 Expand-Archive daemon.zip -DestinationPath app\dist\
 dir app\dist\ # verify that daemon binary is there

--- a/build/build.sh
+++ b/build/build.sh
@@ -80,7 +80,8 @@ else
   OSNAME="linux"
 fi
 DAEMON_VER=$(node -e "console.log(require(\"$ROOT/app/package.json\").lbrySettings.lbrynetDaemonVersion)")
-DAEMON_URL="https://github.com/lbryio/lbry/releases/download/v${DAEMON_VER}/lbrynet-daemon-v${DAEMON_VER}-${OSNAME}.zip"
+DAEMON_URL_TEMPLATE=$(node -e "console.log(require(\"$ROOT/app/package.json\").lbrySettings.lbrynetDaemonUrlTemplate)")
+DAEMON_URL=$(echo ${DAEMON_URL_TEMPLATE//DAEMONVER/$DAEMON_VER} | sed "s/OSNAME/$OSNAME/g")
 wget --quiet "$DAEMON_URL" -O "$BUILD_DIR/daemon.zip"
 unzip "$BUILD_DIR/daemon.zip" -d "$ROOT/app/dist/"
 rm "$BUILD_DIR/daemon.zip"


### PR DESCRIPTION
Now both the daemon URL template and the daemon version are stored in `app/package.json`. Also fixes a couple of places that were still using the old `DAEMON_URL` file.