### PR TITLE
Configure bumpversion to avoid modifying daemon version in package.json

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -17,6 +17,10 @@ values =
 	production
 
 [bumpversion:file:app/package.json]
+search = "version": "{current_version}"
+replace = "version": "{new_version}"
 
 [bumpversion:file:ui/package.json]
+search = "version": "{current_version}"
+replace = "version": "{new_version}"
 


### PR DESCRIPTION
Before, it was matching *any* instance of the current app version string, so if the daemon version configured in app/package.json happened to match the app version, it would get bumped.

This updates the bumpversion config to only update the line containing the package version itself.