### PR TITLE
Fix for broken published links in published tab

### DIFF
--- a/ui/js/reducers/claims.js
+++ b/ui/js/reducers/claims.js
@@ -50,7 +50,7 @@ reducers[types.FETCH_CLAIM_LIST_MINE_COMPLETED] = function(state, action) {
       .filter(claimId => Object.keys(abandoningById).indexOf(claimId) === -1)
   );
 
-  claims.forEach(claim => {
+  claims.filter(claim => claim.category.match(/claim/)).forEach(claim => {
     byId[claim.claim_id] = claim;
 
     const pending = Object.values(pendingById).find(pendingClaim => {


### PR DESCRIPTION
It should fix all of #384 as it was being caused by the function taking the last claim info, if there were many with the same claim id, now it only takes the claims into accounts(not supports or channels).