### PR TITLE
Fix for #461

### DIFF
--- a/ui/js/actions/content.js
+++ b/ui/js/actions/content.js
@@ -336,7 +336,7 @@ export function doPurchaseUri(uri, purchaseModalName) {
     const { cost } = costInfo;
 
     // the file is free or we have partially downloaded it
-    if (cost <= 0.01 || (fileInfo && fileInfo.download_directory)) {
+    if (cost === 0 || (fileInfo && fileInfo.download_directory)) {
       dispatch(doLoadVideo(uri));
       return Promise.resolve();
     }

--- a/ui/js/component/common.js
+++ b/ui/js/component/common.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { formatCredits } from "utils";
+import { formatCredits, formatFullPrice } from "utils";
 import lbry from "../lbry.js";
 
 //component/icon.js
@@ -85,9 +85,10 @@ export class CreditAmount extends React.PureComponent {
     const { amount, precision, showFullPrice } = this.props;
 
     let formattedAmount;
+    let fullPrice = formatFullPrice(amount, 2);
 
     if (showFullPrice) {
-      formattedAmount = amount;
+      formattedAmount = fullPrice;
     } else {
       formattedAmount = amount > 0 && amount < minimumRenderableAmount
         ? "<" + minimumRenderableAmount
@@ -109,7 +110,7 @@ export class CreditAmount extends React.PureComponent {
     return (
       <span
         className={`credit-amount credit-amount--${this.props.look}`}
-        title={amount}
+        title={fullPrice}
       >
         <span>
           {amountText}

--- a/ui/js/component/common.js
+++ b/ui/js/component/common.js
@@ -68,23 +68,32 @@ export class CreditAmount extends React.PureComponent {
     isEstimate: React.PropTypes.bool,
     label: React.PropTypes.bool,
     showFree: React.PropTypes.bool,
+    showFullPrice: React.PropTypes.bool,
     look: React.PropTypes.oneOf(["indicator", "plain"]),
   };
 
   static defaultProps = {
     precision: 2,
     label: true,
-    showFree: false,
     look: "indicator",
+    showFree: false,
+    showFullPrice: false,
   };
 
   render() {
     const minimumRenderableAmount = Math.pow(10, -1 * this.props.precision);
-    const { amount, precision } = this.props;
+    const { amount, precision, showFullPrice } = this.props;
 
-    let formattedAmount = amount > 0 && amount < minimumRenderableAmount
-      ? "<" + minimumRenderableAmount
-      : formatCredits(amount, precision);
+    let formattedAmount;
+    let fullPrice = formatCredits(amount, 5);
+
+    if (showFullPrice) {
+      formattedAmount = fullPrice;
+    } else {
+      formattedAmount = amount > 0 && amount < minimumRenderableAmount
+        ? "<" + minimumRenderableAmount
+        : formatCredits(amount, precision);
+    }
 
     let amountText;
     if (this.props.showFree && parseFloat(this.props.amount) === 0) {
@@ -99,7 +108,10 @@ export class CreditAmount extends React.PureComponent {
     }
 
     return (
-      <span className={`credit-amount credit-amount--${this.props.look}`}>
+      <span
+        className={`credit-amount credit-amount--${this.props.look}`}
+        title={fullPrice}
+      >
         <span>
           {amountText}
         </span>

--- a/ui/js/component/common.js
+++ b/ui/js/component/common.js
@@ -85,10 +85,9 @@ export class CreditAmount extends React.PureComponent {
     const { amount, precision, showFullPrice } = this.props;
 
     let formattedAmount;
-    let fullPrice = formatCredits(amount, 5);
 
     if (showFullPrice) {
-      formattedAmount = fullPrice;
+      formattedAmount = amount;
     } else {
       formattedAmount = amount > 0 && amount < minimumRenderableAmount
         ? "<" + minimumRenderableAmount
@@ -110,7 +109,7 @@ export class CreditAmount extends React.PureComponent {
     return (
       <span
         className={`credit-amount credit-amount--${this.props.look}`}
-        title={fullPrice}
+        title={amount}
       >
         <span>
           {amountText}

--- a/ui/js/component/fileActions/view.jsx
+++ b/ui/js/component/fileActions/view.jsx
@@ -189,7 +189,7 @@ class FileActions extends React.PureComponent {
         >
           {__("This will purchase")} <strong>{title}</strong> {__("for")}{" "}
           <strong>
-            <FilePrice uri={uri} look="plain" />
+            <FilePrice uri={uri} showFullPrice={true} look="plain" />
           </strong>{" "}
           {__("credits")}.
         </Modal>
@@ -198,7 +198,8 @@ class FileActions extends React.PureComponent {
           contentLabel={__("Download failed")}
           onConfirmed={closeModal}
         >
-          {__("LBRY was unable to download the stream")} <strong>{uri}</strong>.
+          {__("LBRY was unable to download the stream")}{" "}{" "}
+          <strong>{title}</strong>.
         </Modal>
         {modal == modals.CONFIRM_FILE_REMOVE &&
           <ModalRemoveFile

--- a/ui/js/component/filePrice/view.jsx
+++ b/ui/js/component/filePrice/view.jsx
@@ -19,7 +19,7 @@ class FilePrice extends React.PureComponent {
   }
 
   render() {
-    const { costInfo, look = "indicator" } = this.props;
+    const { costInfo, look = "indicator", showFullPrice = false } = this.props;
 
     const isEstimate = costInfo ? !costInfo.includesData : null;
 
@@ -35,6 +35,7 @@ class FilePrice extends React.PureComponent {
         amount={costInfo.cost}
         isEstimate={isEstimate}
         showFree={true}
+        showFullPrice={showFullPrice}
       />
     );
   }

--- a/ui/js/component/video/internal/play-button.jsx
+++ b/ui/js/component/video/internal/play-button.jsx
@@ -83,7 +83,7 @@ class VideoPlayButton extends React.PureComponent {
         >
           {__("This will purchase")} <strong>{title}</strong> {__("for")}{" "}
           <strong>
-            <FilePrice uri={uri} look="plain" />
+            <FilePrice uri={uri} showFullPrice={true} look="plain" />
           </strong>{" "}
           {__("credits")}.
         </Modal>

--- a/ui/js/utils.js
+++ b/ui/js/utils.js
@@ -35,3 +35,24 @@ export function setSession(key, value) {
 export function formatCredits(amount, precision) {
   return amount.toFixed(precision || 1).replace(/\.?0+$/, "");
 }
+
+export function formatFullPrice(amount, precision) {
+  let formated = "";
+
+  const quantity = amount.toString().split(".");
+  const fraction = quantity[1];
+
+  if (fraction) {
+    // Set precision
+    precision = precision || 1;
+
+    const decimals = fraction.split("");
+    const first = decimals.filter(number => number != "0")[0];
+    const index = decimals.indexOf(first);
+
+    // Set format fraction
+    formated = "." + fraction.substring(0, index + precision);
+  }
+
+  return parseFloat(quantity[0] + formated);
+}


### PR DESCRIPTION
### Fixes
> There is no confirmation box to purchase the content even though 0.01 LBC is charged.

Fixes https://github.com/lbryio/lbry-app/issues/461#issuecomment-323383905 , https://github.com/lbryio/lbry-app/issues/328#issuecomment-320524216

### Todo
- [x] Enable purchase confirmation modal when price: `cost < 0.1`
- [x] Confirmation dialog show the full price: https://github.com/lbryio/lbry-app/issues/461#issuecomment-324387270
- [x] Test it.
- [x] Display title on error message -> `Failed to download`.
- [x] Implement smart format for full price: [gist/btzr-io/format](https://gist.github.com/btzr-io/e9a2b0f8cf5dcde3a0ee0ec2f0a0aa15)