### PR TITLE
Indicate downloaded/published files in file tiles

### DIFF
--- a/ui/js/component/fileCard/view.jsx
+++ b/ui/js/component/fileCard/view.jsx
@@ -4,6 +4,7 @@ import CardMedia from "component/cardMedia";
 import Link from "component/link";
 import { TruncatedText, Icon } from "component/common";
 import IconFeatured from "component/iconFeatured";
+import IconDownloaded from "component/iconDownloaded";
 import FilePrice from "component/filePrice";
 import UriIndicator from "component/uriIndicator";
 import NsfwOverlay from "component/nsfwOverlay";
@@ -97,8 +98,7 @@ class FileCard extends React.PureComponent {
                 <span style={{ float: "right" }}>
                   <FilePrice uri={uri} />
                   {isRewardContent && <span>{" "}<IconFeatured /></span>}
-                  {fileInfo &&
-                    <span>{" "}<Icon fixed icon="icon-folder" /></span>}
+                  {fileInfo && <span>{" "}<IconDownloaded /></span>}
                 </span>
                 <UriIndicator uri={uri} />
               </div>

--- a/ui/js/component/fileList/view.jsx
+++ b/ui/js/component/fileList/view.jsx
@@ -83,7 +83,7 @@ class FileList extends React.PureComponent {
         <FileTile
           key={fileInfo.outpoint || fileInfo.claim_id}
           uri={uri}
-          hidePrice={true}
+          local={true}
           showEmpty={this.props.fileTileShowEmpty}
         />
       );

--- a/ui/js/component/fileTile/view.jsx
+++ b/ui/js/component/fileTile/view.jsx
@@ -6,10 +6,15 @@ import { TruncatedText } from "component/common.js";
 import FilePrice from "component/filePrice";
 import NsfwOverlay from "component/nsfwOverlay";
 import IconFeatured from "component/iconFeatured";
+import IconDownloaded from "component/iconDownloaded";
 
 class FileTile extends React.PureComponent {
   static SHOW_EMPTY_PUBLISH = "publish";
   static SHOW_EMPTY_PENDING = "pending";
+
+  static defaultProps = {
+    local: false,
+  };
 
   constructor(props) {
     super(props);
@@ -53,11 +58,12 @@ class FileTile extends React.PureComponent {
   render() {
     const {
       claim,
+      fileInfo,
       metadata,
       isResolvingUri,
       showEmpty,
       navigate,
-      hidePrice,
+      local,
       rewardedContentClaimIds,
     } = this.props;
 
@@ -109,8 +115,11 @@ class FileTile extends React.PureComponent {
             <CardMedia title={title} thumbnail={thumbnail} />
             <div className="file-tile__content">
               <div className="card__title-primary">
-                {!hidePrice ? <FilePrice uri={this.props.uri} /> : null}
-                {isRewardContent && <IconFeatured />}
+                {!local ? <FilePrice uri={this.props.uri} /> : null}
+                <span className="file-tile__icons">
+                  {isRewardContent && <IconFeatured />}
+                  {fileInfo && !local && <span>{" "}<IconDownloaded /></span>}
+                </span>
                 <div className="meta">{uri}</div>
                 <h3>
                   <TruncatedText lines={1}>{title}</TruncatedText>

--- a/ui/js/component/iconDownloaded/index.js
+++ b/ui/js/component/iconDownloaded/index.js
@@ -1,0 +1,5 @@
+import React from "react";
+import { connect } from "react-redux";
+import IconDownloaded from "./view";
+
+export default connect(null, null)(IconDownloaded);

--- a/ui/js/component/iconDownloaded/view.jsx
+++ b/ui/js/component/iconDownloaded/view.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { Icon } from "component/common.js";
+
+const IconDownloaded = props => {
+  return (
+    <span
+      className="icon-downloaded"
+      title={__("You've already downloaded this content.")}
+    >
+      <Icon icon="icon-folder" fixed className="card__icon-downloaded" />
+    </span>
+  );
+};
+
+export default IconDownloaded;

--- a/ui/scss/component/_card.scss
+++ b/ui/scss/component/_card.scss
@@ -260,3 +260,7 @@ $padding-right-card-hover-hack: 30px;
 .card__icon-featured-content {
   color: orangered;
 }
+
+.card__icon-downloaded {
+  color: rgba(0, 0, 0, 0.6);
+}

--- a/ui/scss/component/_file-tile.scss
+++ b/ui/scss/component/_file-tile.scss
@@ -7,7 +7,7 @@ $height-file-tile: $spacing-vertical * 6;
   .credit-amount {
     float: right;
   }
-  .icon-featured {
+  .file-tile__icons {
     float: right;
   }
   //also a hack


### PR DESCRIPTION
Adds the same folder icon that's there in file cards.

Also includes some minor CSS improvements and JS refactoring.