### PR TITLE
Return proper URI when channel name is present.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Web UI version numbers should always match the corresponding version of LBRY App
   * Fixed sizing on squat videos (#419)
   * Support claims no longer show up on Published page (#384)
   * Fixed rendering of small prices (#461)
+  * Fixed incorrect URI in Downloads/Published page (#460)
 
 ### Deprecated
   *

--- a/ui/js/component/fileList/view.jsx
+++ b/ui/js/component/fileList/view.jsx
@@ -67,12 +67,13 @@ class FileList extends React.PureComponent {
     const content = [];
 
     this._sortFunctions[sortBy](fileInfos).forEach(fileInfo => {
-      let uriParams = {
-        claimId: fileInfo.claim_id,
-      };
+      let uriParams = {};
+
       if (fileInfo.channel_name) {
         uriParams.channelName = fileInfo.channel_name;
         uriParams.contentName = fileInfo.name;
+        // The following can be done as certificateID of a claim is nothing but the claimID of the channel.
+        uriParams.claimId = fileInfo.value.publisherSignature.certificateId;
       } else {
         uriParams.claimId = fileInfo.claim_id;
         uriParams.name = fileInfo.name;


### PR DESCRIPTION
FIx for #460. Now the channel's claim_id is appended in after the channel_name in the URI.