### PR TITLE
Show most recent claims first on channel pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Web UI version numbers should always match the corresponding version of LBRY App
   * Updated several packages and fixed warnings in build process (all but the [fsevents warning](https://github.com/yarnpkg/yarn/issues/3738), which is a rather dramatic debate)
 
 ### Fixed
+  * Show most recent content first on channel pages (#479)
   * Tiles will no longer be blurry on hover (Windows only bug)
   * Removed placeholder values from price selection form fields, which was causing confusion that these were real values (#426)
   * Fixed showing "other currency" help tip in publish form, which was caused due to not "setting" state for price

--- a/ui/js/page/channel/view.jsx
+++ b/ui/js/page/channel/view.jsx
@@ -48,7 +48,7 @@ class ChannelPage extends React.PureComponent {
       contentList = <BusyMessage message={__("Fetching content")} />;
     } else if (claimsInChannel) {
       contentList = claimsInChannel.length
-        ? claimsInChannel.map(claim =>
+        ? claimsInChannel.reverse().map(claim =>
             <FileTile
               key={claim.claim_id}
               uri={lbryuri.build({


### PR DESCRIPTION
@kauffj: Seems like this is all it will take to fix #479, unless we want lbrynet to return the content newest first?