### PR TITLE
Fixed regression in #501

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Web UI version numbers should always match the corresponding version of LBRY App
 
 ### Fixed
  * Corrected improper pluralization on loading screen
+ * Regression in #501
 
 
 

--- a/ui/js/component/fileList/view.jsx
+++ b/ui/js/component/fileList/view.jsx
@@ -51,6 +51,14 @@ class FileList extends React.PureComponent {
     };
   }
 
+  getChannelSignature(fileInfo) {
+    if (fileInfo.value) {
+      return fileInfo.value.publisherSignature.certificateId;
+    } else {
+      return fileInfo.metadata.publisherSignature.certificateId;
+    }
+  }
+
   handleSortChanged(event) {
     this.setState({
       sortBy: event.target.value,
@@ -69,7 +77,7 @@ class FileList extends React.PureComponent {
         uriParams.channelName = fileInfo.channel_name;
         uriParams.contentName = fileInfo.name;
         // The following can be done as certificateID of a claim is nothing but the claimID of the channel.
-        uriParams.claimId = fileInfo.value.publisherSignature.certificateId;
+        uriParams.claimId = this.getChannelSignature(fileInfo);
       } else {
         uriParams.claimId = fileInfo.claim_id;
         uriParams.name = fileInfo.name;


### PR DESCRIPTION
- [x] Beat @wallermadev to the PR
- [x] Fix the regression

This is a temporary fix, but I think the daemon should return consistent result whether it be `file_list` or `claim_list_mine`.