### PR TITLE
Fix #503

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Web UI version numbers should always match the corresponding version of LBRY App
   * Support claims no longer show up on Published page (#384)
   * Fixed rendering of small prices (#461)
   * Fixed incorrect URI in Downloads/Published page (#460)
+  * Fixed menu bug (#503)
 
 ### Deprecated
   *

--- a/ui/js/component/menu.js
+++ b/ui/js/component/menu.js
@@ -69,7 +69,7 @@ export class DropDownMenu extends React.PureComponent {
     });
   }
 
-  handleWindowClick(e) {
+  handleWindowClick = (e) => {
     if (
       this.state.menuOpen &&
       (!this._menuDiv || !this._menuDiv.contains(e.target))


### PR DESCRIPTION
### Fixes
> The menu don't close, and throws an error:

Fix `handleWindowClick()`, and remove error: 
```
Cannot read property 'menuOpen' of undefined
```
### Todo
- [x] Update changelog.md.