### PR TITLE
Get the app directory via an absolute path instead of a relative one.

### DIFF
--- a/ui/js/actions/settings.js
+++ b/ui/js/actions/settings.js
@@ -4,7 +4,6 @@ import batchActions from "util/batchActions";
 import lbry from "lbry";
 import fs from "fs";
 import http from "http";
-import { remote } from "electron";
 
 export function doFetchDaemonSettings() {
   return function(dispatch, getState) {

--- a/ui/js/actions/settings.js
+++ b/ui/js/actions/settings.js
@@ -4,6 +4,7 @@ import batchActions from "util/batchActions";
 import lbry from "lbry";
 import fs from "fs";
 import http from "http";
+import { remote } from "electron";
 
 export function doFetchDaemonSettings() {
   return function(dispatch, getState) {
@@ -48,7 +49,7 @@ export function doSetClientSetting(key, value) {
 
 export function doDownloadLanguage(langFile) {
   return function(dispatch, getState) {
-    const destinationPath = `app/locales/${langFile}`;
+    const destinationPath = app.i18n.directory + "/" + langFile;
     const language = langFile.replace(".json", "");
     const req = http.get(
       {

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -1,5 +1,6 @@
 import store from "store.js";
 import lbry from "./lbry.js";
+import { remote } from "electron";
 import * as settings from "constants/settings";
 
 const env = ENV;
@@ -10,7 +11,7 @@ const language = lbry.getClientSetting(settings.LANGUAGE)
   ? lbry.getClientSetting(settings.LANGUAGE)
   : "en";
 const i18n = require("y18n")({
-  directory: "app/locales",
+  directory: remote.app.getAppPath() + "/locales",
   updateFiles: false,
   locale: language,
 });


### PR DESCRIPTION
In the internationalization code it is assumed that the app directory is in the current working directory.
This causes problems when the current working directory is not where it is expected. Before some of the internationalization code was temporarily disabled (a return was inserted at the begging of the doDownloadLanguages function), on startup it would get stuck and display a pure cyan screen. In the background it would start the daemon and everything, but it would not display anything but the cyan background. This was reported by me in #516.
This PR proposes that instead of assuming that the app folder for the application is in our current working directory, we grab the path of the app folder directly from Electron itself. We grab this directory by using Electron's remote module, which is made to be used by the render thread, to grab an instance of the Electron app object to get the path that we need.