### PR TITLE
Publish Drag-and-Drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Web UI version numbers should always match the corresponding version of LBRY App
 
 ## [Unreleased]
 ### Added
+  * Publishing now supports drag-and-drop file selection.
   * Add setting to automatically purchase low-cost content without a confirmation dialog
   *
 

--- a/ui/js/component/app/view.jsx
+++ b/ui/js/component/app/view.jsx
@@ -17,6 +17,16 @@ class App extends React.PureComponent {
       alertError(event.detail);
     });
 
+    document.addEventListener("drop", event => {
+      event.preventDefault();
+      event.stopPropagation();
+    });
+
+    document.addEventListener("dragover", event => {
+      event.preventDefault();
+      event.stopPropagation();
+    });
+
     if (!this.props.upgradeSkipped) {
       checkUpgradeAvailable();
     }

--- a/ui/js/component/publishForm/internal/dropzone.jsx
+++ b/ui/js/component/publishForm/internal/dropzone.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+class DropZone extends React.PureComponent {
+  render() {
+    return (
+      <div className="dropzone">
+        <div className="textnode">Drop here!</div>
+      </div>
+    );
+  }
+}
+
+export default DropZone;

--- a/ui/js/component/publishForm/view.jsx
+++ b/ui/js/component/publishForm/view.jsx
@@ -8,6 +8,7 @@ import FormFieldPrice from "component/formFieldPrice";
 import Modal from "modal/modal";
 import { BusyMessage } from "component/common";
 import ChannelSection from "./internal/channelSection";
+import DropZone from "./internal/dropzone";
 
 class PublishForm extends React.PureComponent {
   constructor(props) {
@@ -51,6 +52,8 @@ class PublishForm extends React.PureComponent {
       customUrl: false,
       source: null,
       mode: "publish",
+      showDropzone: false,
+      enterTarget: null,
     };
   }
 
@@ -516,6 +519,57 @@ class PublishForm extends React.PureComponent {
     });
   }
 
+  handleFileSelect(event) {
+    event.stopPropagation();
+    event.preventDefault();
+
+    // FileList object.
+    var file = event.dataTransfer.files;
+
+    // file is a FileList of File objects.
+    let f = file[0];
+
+    this.setState({
+      source: f.path,
+      hasFile: true,
+      showDropzone: false,
+      enterTarget: null,
+    });
+
+    // This doesn't work, but we need to be able to do this, or something else to display it in the UI.
+    this.refs.file.value = f.path;
+    console.log(this.refs.file.getValue());
+    let fileName = this._getFileName(f.path);
+    this.nameChanged(fileName);
+  }
+
+  handleDragOver(event) {
+    event.stopPropagation();
+    event.preventDefault();
+    // Explicitly show this is a copy.
+    event.dataTransfer.dropEffect = "copy";
+  }
+
+  handleDragEnter(event) {
+    // This includes the fix for component redrawing on mouse move
+    // https://stackoverflow.com/questions/7110353/html5-dragleave-fired-when-hovering-a-child-element
+    event.preventDefault();
+    this.setState({
+      showDropzone: true,
+      enterTarget: event.target,
+    });
+  }
+
+  handleDragLeave(event) {
+    event.preventDefault();
+    if (this.state.enterTarget == event.target) {
+      this.setState({
+        showDropzone: false,
+        enterTarget: null,
+      });
+    }
+  }
+
   render() {
     const { mode, submitting } = this.state;
 
@@ -531,7 +585,14 @@ class PublishForm extends React.PureComponent {
 
     return (
       <main className="main--single-column">
-        <Form onSubmit={this.handleSubmit.bind(this)}>
+        <Form
+          onSubmit={this.handleSubmit.bind(this)}
+          onDrop={this.handleFileSelect.bind(this)}
+          onDragOver={this.handleDragOver.bind(this)}
+          onDragEnter={this.handleDragEnter.bind(this)}
+          onDragLeave={this.handleDragLeave.bind(this)}
+        >
+          {this.state.showDropzone && <DropZone />}
           <section className="card">
             <div className="card__title-primary">
               <h4>{__("Content")}</h4>

--- a/ui/scss/all.scss
+++ b/ui/scss/all.scss
@@ -15,6 +15,7 @@
 @import "component/_tooltip.scss";
 @import "component/_load-screen.scss";
 @import "component/_channel-indicator.scss";
+@import "component/_dropzone.scss";
 @import "component/_notice.scss";
 @import "component/_modal.scss";
 @import "component/_snack-bar.scss";

--- a/ui/scss/component/_dropzone.scss
+++ b/ui/scss/component/_dropzone.scss
@@ -1,0 +1,23 @@
+@import "../global";
+
+.dropzone {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 2;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(200, 200, 200, 0.5);
+  transition: visibility 175ms, opacity 175ms;
+  display: table;
+  text-shadow: 2px 1px 5px #000;
+  color: #fff;
+  -webkit-text-stroke-width: 1px;
+  -webkit-text-stroke-color: #000;
+  font: bold 42px Oswald, DejaVu Sans, Tahoma, sans-serif;
+}
+.textnode {
+  display: table-cell;
+  text-align: center;
+  vertical-align: middle;
+}


### PR DESCRIPTION
@kauffj 
- This is able to get the file's path(in the `source` state), but not able to display it in the `FormRow` compnent
- This also computes a name for the file based on path
- An overlay is shown when a file is dragged on the form window.(CSS is just a place-holder, since I was not sure about it)
- This also fixes the bug due to which dragging a file open it in the app.

Closes #350 