### PR TITLE
Fix #543

### DIFF
--- a/ui/scss/_icons.scss
+++ b/ui/scss/_icons.scss
@@ -1658,3 +1658,9 @@
 .icon-medium:before {
   content: "\f23a";
 }
+.icon-address-book:before {
+  content: "\f2b9";
+}
+.icon-envelope-open:before {
+  content: "\f2b6";
+}


### PR DESCRIPTION
> The Recieve and Invites screens are missing their respective icons in the LBRY App address bar. The other screens each have an icon.