### PR TITLE
change message if all rewards redeemed

### DIFF
--- a/ui/js/page/rewards/view.jsx
+++ b/ui/js/page/rewards/view.jsx
@@ -114,7 +114,7 @@ class RewardsPage extends React.PureComponent {
     } else if (!rewards || rewards.length <= 0) {
       return (
         <div className="card__content empty">
-          {__("Failed to load rewards.")}
+          {__("There are no rewards available at this time, please check back later.")}
         </div>
       );
     } else {


### PR DESCRIPTION
Change failed message to: "There are no rewards available at this time, please check back later."

This scenario happens when all rewards are claimed. Not sure if it can be encountered any other time.