### PR TITLE
update disabled reward text

### DIFF
--- a/ui/js/page/rewards/view.jsx
+++ b/ui/js/page/rewards/view.jsx
@@ -75,7 +75,7 @@ class RewardsPage extends React.PureComponent {
               )}
             </p>
             <p>
-              {__("You will receive an email when this process is complete.") +
+              {__("If you continue to see this message, send us an email to help@lbry.io.") +
                 " " +
                 __("Please enjoy free content in the meantime!")}
             </p>


### PR DESCRIPTION
This message appears when a user's account is manually disabled (rewards abuse, etc).  We don't reach out to them via email, so we should ask them to reach out if they are actually legitimate users.