### PR TITLE
add changelog link

### DIFF
--- a/ui/js/modal/modalUpgrade/view.jsx
+++ b/ui/js/modal/modalUpgrade/view.jsx
@@ -18,6 +18,10 @@ class ModalUpgrade extends React.PureComponent {
         {__(
           "Your version of LBRY is out of date and may be unreliable or insecure."
         )}
+        <Link
+          label={__("Learn more")}
+          href="https://github.com/lbryio/lbry-app/releases"
+        />
       </Modal>
     );
   }


### PR DESCRIPTION
Add hyperlink to releases page which has the changelog. Had a complaint recently that we don't show what changed when prompting to update - kind of makes sense to have it here. 