### PR TITLE
Fixes #614, Makes things consistent to allow sorting by title

### DIFF
--- a/ui/js/component/fileList/view.jsx
+++ b/ui/js/component/fileList/view.jsx
@@ -18,12 +18,8 @@ class FileList extends React.PureComponent {
       },
       title: function(fileInfos) {
         return fileInfos.slice().sort(function(fileInfo1, fileInfo2) {
-          const title1 = fileInfo1.metadata
-            ? fileInfo1.metadata.stream.metadata.title.toLowerCase()
-            : fileInfo1.name;
-          const title2 = fileInfo2.metadata
-            ? fileInfo2.metadata.stream.metadata.title.toLowerCase()
-            : fileInfo2.name;
+          const title1 = fileInfo1.name.toLowerCase();
+          const title2 = fileInfo2.name.toLowerCase();
           if (title1 < title2) {
             return -1;
           } else if (title1 > title2) {
@@ -79,7 +75,7 @@ class FileList extends React.PureComponent {
         uriParams.claimId = this.getChannelSignature(fileInfo);
       } else {
         uriParams.claimId = fileInfo.claim_id;
-        uriParams.name = fileInfo.name;
+        uriParams.contentName = fileInfo.name;
       }
       const uri = lbryuri.build(uriParams);
 


### PR DESCRIPTION
[#614](https://github.com/lbryio/lbry-app/issues/614)

Basically, the component `FileTile` displays *title* using
`lbryuri.parse(uri).contentName;` and not `metadata.title` cause it's
never passed to the component and `title` prop does not exist anyway
(see *FileList* with *fileInfos* object).

`.contentName` is filled with `fileInfos.name` value.

So to make all things **consistent**, we simply need to use
`fileInfo.name` in our comparaison function.