### PR TITLE
Better title for menu bar

### DIFF
--- a/ui/js/component/app/view.jsx
+++ b/ui/js/component/app/view.jsx
@@ -39,7 +39,7 @@ class App extends React.PureComponent {
   }
 
   setTitleFromProps(props) {
-    window.document.title = props.pageTitle;
+    window.document.title = props.pageTitle || "LBRY";
   }
 
   render() {


### PR DESCRIPTION
### Fixes
> Home page menu bar shows index.html.  

If no title is set, it would always show the current file path (`./index.html`)

### Changes
Display the application name as default title.
