### PR TITLE
Menu patch

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -1,6 +1,7 @@
 const {app, BrowserWindow, ipcMain} = require('electron');
 const url = require('url');
-const isDebug = process.env.NODE_ENV === 'development'
+const isDebug = process.env.NODE_ENV === 'development';
+const setMenu = require('./menu/main-menu.js');
 
 if (isDebug) {
   try
@@ -169,6 +170,12 @@ function createWindow () {
   win.on('closed', () => {
     win = null
   })
+
+  // Menu bar
+  win.setAutoHideMenuBar(true);
+  win.setMenuBarVisibility(isDebug);
+  setMenu();
+
 };
 
 function handleOpenUriRequested(uri) {

--- a/app/menu/main-menu.js
+++ b/app/menu/main-menu.js
@@ -1,6 +1,4 @@
-const {Menu} = require('electron');
-const electron = require('electron');
-const app = electron.app;
+const { app, shell, Menu } = require('electron');
 
 const baseTemplate = [
   {
@@ -30,16 +28,71 @@ const baseTemplate = [
     ]
   },
   {
-    label: 'Help',
+    label: 'View',
     submenu: [
       {
-        label: 'Help',
+        role: 'reload'
+      },
+      {
+        label: 'Developer',
+        submenu: [
+          {
+            role: 'forcereload'
+          },
+          {
+            role: 'toggledevtools'
+          },
+        ]
+      },
+      {
+        type: 'separator'
+      },
+      {
+        role: 'togglefullscreen'
+      }
+    ]
+  },
+  {
+    role: 'help',
+    submenu: [
+      {
+        label: 'Learn More',
         click(item, focusedWindow) {
           if (focusedWindow) {
             focusedWindow.webContents.send('open-menu', '/help');
           }
         }
+      },
+      {
+        label: 'Frequently Asked Questions',
+        click(item, focusedWindow){
+         shell.openExternal('https://lbry.io/faq')
       }
+      },
+      {
+        type: 'separator'
+      },
+      {
+        label: 'Report Issue',
+        click(item, focusedWindow){
+          shell.openExternal('https://lbry.io/faq/contributing#report-a-bug');
+        }
+      },
+      {
+        label: 'Search Issues',
+        click(item, focusedWindow){
+          shell.openExternal('https://github.com/lbryio/lbry-app/issues')
+        }
+      },
+      {
+        type: 'separator'
+      },
+      {
+        label: 'Quickstart Guide',
+        click(item, focusedWindow){
+          shell.openExternal('https://lbry.io/quickstart')
+        }
+      },
     ]
   }
 ];
@@ -71,40 +124,8 @@ const macOSAppMenuTemplate = {
   ]
 };
 
-const developerMenuTemplate = {
-  label: 'Developer',
-  submenu: [
-    {
-      label: 'Reload',
-      accelerator: 'CmdOrCtrl+R',
-      click(item, focusedWindow) {
-        if (focusedWindow) {
-          focusedWindow.reload();
-        }
-      }
-    },
-    {
-      label: 'Toggle Developer Tools',
-      accelerator: process.platform == 'darwin' ? 'Alt+Command+I' : 'Ctrl+Shift+I',
-      click(item, focusedWindow) {
-        if (focusedWindow) {
-          focusedWindow.webContents.toggleDevTools();
-        }
-      }
-    },
-  ]
-};
-
-module.exports = {
-  showMenubar(showDeveloperMenu) {
+module.exports = () => {
     let template = baseTemplate.slice();
-    if (process.platform === 'darwin') {
-      template.unshift(macOSAppMenuTemplate);
-    }
-    if (showDeveloperMenu) {
-      template.push(developerMenuTemplate);
-    }
-
+    (process.platform === 'darwin') && template.unshift(macOSAppMenuTemplate);
     Menu.setApplicationMenu(Menu.buildFromTemplate(template));
-  },
 };

--- a/app/menu/main-menu.js
+++ b/app/menu/main-menu.js
@@ -79,16 +79,10 @@ const baseTemplate = [
         }
       },
       {
-        label: 'Search Issues',
-        click(item, focusedWindow){
-          shell.openExternal('https://github.com/lbryio/lbry-app/issues')
-        }
-      },
-      {
         type: 'separator'
       },
       {
-        label: 'Quickstart Guide',
+        label: 'Developer API Guide',
         click(item, focusedWindow){
           shell.openExternal('https://lbry.io/quickstart')
         }


### PR DESCRIPTION
### Fixes
> Allow access to Developer Tools / Reload functionality #672 

> Copy-paste keyboard hotkeys into and out of app UI #685 

### Changes
- Toggle `menuBar` visibility ( hidden by default )
- New additional shortcut: `toggleFullScreen`
- Make all shortcuts work again.