### PR TITLE
Fixed parsing of channel names of length < 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Web UI version numbers should always match the corresponding version of LBRY App
 
 ### Fixed
   * Fixed handling of empty search results.
-  *
+  * Fixed minimum channel length name(#689).
 
 ### Deprecated
   *

--- a/ui/js/lbryuri.js
+++ b/ui/js/lbryuri.js
@@ -1,4 +1,4 @@
-const CHANNEL_NAME_MIN_LEN = 4;
+const CHANNEL_NAME_MIN_LEN = 1;
 const CLAIM_ID_MAX_LEN = 40;
 
 const lbryuri = {};


### PR DESCRIPTION
Should be a fix for #689 and I think this was the only reference to the length of channel name.