### PR TITLE
Issue #721 fix - Inconsistent thumbnail sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Web UI version numbers should always match the corresponding version of LBRY App
   *
 
 ### Fixed
-  *
+  * Long channel names causing inconsistent thumbnail sizes (#721)
   *
 
 ### Deprecated

--- a/ui/js/component/uriIndicator/view.jsx
+++ b/ui/js/component/uriIndicator/view.jsx
@@ -60,7 +60,7 @@ class UriIndicator extends React.PureComponent {
 
     const inner = (
       <span>
-        {channelName} {" "}
+        <span className="channel-name">{channelName}</span> {" "}
         {!signatureIsValid
           ? <Icon
               icon={icon}

--- a/ui/scss/component/_channel-indicator.scss
+++ b/ui/scss/component/_channel-indicator.scss
@@ -1,4 +1,12 @@
 
+.channel-name {
+  width: calc(var(--card-small-width) * 2 / 3);
+  display: inline-block;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis
+}
+
 .channel-indicator__icon--invalid {
   color: var(--color-error);
 }


### PR DESCRIPTION
Fix for long channel names resulting in the inconsistent thumbnail sizes.