### PR TITLE
refactor scroll navigation/restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,12 @@ Web UI version numbers should always match the corresponding version of LBRY App
   *
 
 ### Changed
-  *
+  * Moved all redux code into /redux folder
   *
 
 ### Fixed
   * Long channel names causing inconsistent thumbnail sizes (#721)
-  *
+  * Fixed scriolling restore/reset/set (#729)
 
 ### Deprecated
   *

--- a/ui/js/component/app/index.js
+++ b/ui/js/component/app/index.js
@@ -1,6 +1,10 @@
 import React from "react";
 import { connect } from "react-redux";
-import { selectPageTitle } from "redux/selectors/navigation";
+import {
+  selectPageTitle,
+  selectHistoryIndex,
+  selectActiveHistoryEntry,
+} from "redux/selectors/navigation";
 import { selectUser } from "redux/selectors/user";
 import { doCheckUpgradeAvailable, doAlertError } from "redux/actions/app";
 import { doRecordScroll } from "redux/actions/navigation";
@@ -10,6 +14,8 @@ import App from "./view";
 const select = (state, props) => ({
   pageTitle: selectPageTitle(state),
   user: selectUser(state),
+  currentStackIndex: selectHistoryIndex(state),
+  currentPageAttributes: selectActiveHistoryEntry(state),
 });
 
 const perform = dispatch => ({

--- a/ui/js/redux/actions/navigation.js
+++ b/ui/js/redux/actions/navigation.js
@@ -21,21 +21,11 @@ export function doNavigate(path, params = {}, options = {}) {
       url += "?" + toQueryString(params);
     }
 
-    const state = getState(),
-      currentPage = selectCurrentPage(state),
-      nextPage = computePageFromPath(path),
-      scrollY = options.scrollY;
-
-    if (currentPage != nextPage) {
-      //I wasn't seeing it scroll to the proper position without this -- possibly because the page isn't fully rendered? Not sure - Jeremy
-      setTimeout(() => {
-        window.scrollTo(0, scrollY ? scrollY : 0);
-      }, 100);
-    }
+    const scrollY = options.scrollY;
 
     dispatch({
       type: types.HISTORY_NAVIGATE,
-      data: { url, index: options.index },
+      data: { url, index: options.index, scrollY },
     });
   };
 }

--- a/ui/js/redux/reducers/navigation.js
+++ b/ui/js/redux/reducers/navigation.js
@@ -32,14 +32,14 @@ reducers[types.CHANGE_AFTER_AUTH_PATH] = function(state, action) {
 
 reducers[types.HISTORY_NAVIGATE] = (state, action) => {
   const { stack, index } = state;
-  const path = action.data.url;
+  const { url: path, index: newIndex, scrollY } = action.data;
 
   let newState = {
     currentPath: path,
   };
 
-  if (action.data.index >= 0) {
-    newState.index = action.data.index;
+  if (newIndex >= 0) {
+    newState.index = newIndex;
   } else if (!stack[index] || stack[index].path !== path) {
     // ^ Check for duplicated
     newState.stack = [...stack.slice(0, index + 1), { path, scrollY: 0 }];
@@ -47,7 +47,6 @@ reducers[types.HISTORY_NAVIGATE] = (state, action) => {
   }
 
   history.replaceState(null, null, "#" + path); //this allows currentPath() to retain the URL on reload
-
   return Object.assign({}, state, newState);
 };
 

--- a/ui/js/redux/selectors/navigation.js
+++ b/ui/js/redux/selectors/navigation.js
@@ -146,3 +146,9 @@ export const selectHistoryStack = createSelector(
   _selectState,
   state => state.stack
 );
+
+// returns current page attributes (scrollY, path)
+export const selectActiveHistoryEntry = createSelector(
+  _selectState,
+  state => state.stack[state.index]
+);

--- a/ui/js/util/throttle.js
+++ b/ui/js/util/throttle.js
@@ -1,0 +1,56 @@
+// Taken from underscore.js (slightly modified to add the getNow function and use const/let over var)
+// https://github.com/jashkenas/underscore/blob/master/underscore.js#L830-L874
+
+// Returns a function, that, when invoked, will only be triggered at most once
+// during a given window of time. Normally, the throttled function will run
+// as much as it can, without ever going more than once per `wait` duration;
+// but if you'd like to disable the execution on the leading edge, pass
+// `{leading: false}`. To disable execution on the trailing edge, ditto.
+export default function throttle(func, wait, options) {
+  let timeout, context, args, result;
+  let previous = 0;
+  const getNow = () => new Date().getTime();
+
+  if (!options) options = {};
+
+  const later = function() {
+    previous = options.leading === false ? 0 : getNow();
+    timeout = null;
+    result = func.apply(context, args);
+    if (!timeout) context = args = null;
+  };
+
+  const throttled = function() {
+    const now = getNow();
+
+    if (!previous && options.leading === false) previous = now;
+
+    const remaining = wait - (now - previous);
+
+    context = this;
+    args = arguments;
+
+    if (remaining <= 0 || remaining > wait) {
+      if (timeout) {
+        clearTimeout(timeout);
+        timeout = null;
+      }
+
+      previous = now;
+      result = func.apply(context, args);
+
+      if (!timeout) context = args = null;
+    } else if (!timeout && options.trailing !== false) {
+      timeout = setTimeout(later, remaining);
+    }
+    return result;
+  };
+
+  throttled.cancel = function() {
+    clearTimeout(timeout);
+    previous = 0;
+    timeout = context = args = null;
+  };
+
+  return throttled;
+}


### PR DESCRIPTION
Doing some refactoring to how the scroll restore works. This fixes the issue where after navigating, pages were scrolled down a bit.

This gets ride of the need to use a `setTimeout` which was required to let the new page load before scrolling. We can handle that inside the app component which I think makes more sense because it is interacting with the DOM. I also added throttling to the scroll listener, no need to constantly fire events when scrolling.

#### After (not sure why my mouse disappeared)
![scroll](https://user-images.githubusercontent.com/16882830/32857350-876a9276-ca15-11e7-8cb5-4390b50f6cc7.gif)

#### Some things to think about/future ideas
Do we want to restore for all pages? Forwards _and_ back? Not really sure.
If users click the `settings` icon while on the settings page, maybe scroll to the top instead of doing nothing?