### PR TITLE
Fixed sorting by title for published files (#614)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Web UI version numbers should always match the corresponding version of LBRY App
   * Long channel names causing inconsistent thumbnail sizes (#721)
   * Fixed regression in #697 causing transaction screen to not load for new users (#755)
   * Fixed scriolling restore/reset/set (#729)
+  * Fixed sorting by title for published files (#614)
 
 ### Deprecated
   *

--- a/ui/js/component/fileList/view.jsx
+++ b/ui/js/component/fileList/view.jsx
@@ -18,11 +18,11 @@ class FileList extends React.PureComponent {
       },
       title: function(fileInfos) {
         return fileInfos.slice().sort(function(fileInfo1, fileInfo2) {
-          const title1 = fileInfo1.metadata
-            ? fileInfo1.metadata.stream.metadata.title.toLowerCase()
+          const title1 = fileInfo1.value
+            ? fileInfo1.value.stream.metadata.title.toLowerCase()
             : fileInfo1.name;
-          const title2 = fileInfo2.metadata
-            ? fileInfo2.metadata.stream.metadata.title.toLowerCase()
+          const title2 = fileInfo2.value
+            ? fileInfo2.value.stream.metadata.title.toLowerCase()
             : fileInfo2.name;
           if (title1 < title2) {
             return -1;


### PR DESCRIPTION
It seemed like the API changed at some point and this wasn't updated. The result was that the published files were sorted by their name and not by their title.