### PR TITLE
[MERGE AFTER lbry@19 upgrade] replace channel_list_mine with channel_list

### DIFF
--- a/ui/js/redux/actions/content.js
+++ b/ui/js/redux/actions/content.js
@@ -444,7 +444,7 @@ export function doFetchChannelListMine() {
       });
     };
 
-    lbry.channel_list_mine().then(callback);
+    lbry.channel_list().then(callback);
   };
 }
 


### PR DESCRIPTION
`channel_list_mine` is deprecated in v19 of `lbry`
https://github.com/lbryio/lbry/releases/tag/v0.19.0rc1

This should be merged when we upgrade to v19

Just adding it now so we can switch over quickly when it's out of rc

cc @jackrobison 