### PR TITLE
Change header balance to 2 decimal places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ Web UI version numbers should always match the corresponding version of LBRY App
   *
 
 ### Changed
+  * The credit balance displayed in the main app navigation displays two decimal places instead of one.
   * Moved all redux code into /redux folder
-  *
 
 ### Fixed
   * Long channel names causing inconsistent thumbnail sizes (#721)

--- a/ui/js/component/header/index.js
+++ b/ui/js/component/header/index.js
@@ -19,7 +19,7 @@ const select = state => ({
   isBackDisabled: selectIsBackDisabled(state),
   isForwardDisabled: selectIsForwardDisabled(state),
   isUpgradeAvailable: selectIsUpgradeAvailable(state),
-  balance: formatCredits(selectBalance(state) || 0, 1),
+  balance: formatCredits(selectBalance(state) || 0, 2),
 });
 
 const perform = dispatch => ({


### PR DESCRIPTION
Several places in the app default to credit values of 0.01. If we are suggesting hundredths based usage of LBC, the balance in the header should also have two decimal places.