### PR TITLE
Added more understandable error message

### DIFF
--- a/src/renderer/js/redux/actions/content.js
+++ b/src/renderer/js/redux/actions/content.js
@@ -280,13 +280,17 @@ export function doLoadVideo(uri) {
           dispatch(doDownloadFile(uri, streamInfo));
         }
       })
-      .catch(error => {
+      .catch(() => {
         dispatch(doSetPlayingUri(null));
         dispatch({
           type: types.LOADING_VIDEO_FAILED,
           data: { uri },
         });
-        dispatch(doAlertError(error));
+        dispatch(
+          doAlertError(
+            `Failed to download ${uri}, please try again. If this problem persists, visit https://lbry.io/faq/support for support.`
+          )
+        );
       });
   };
 }


### PR DESCRIPTION
The old error message was very confusing to users. Users don't need to know about sd hashes and blobs, they just want to understand what the problem pertained to -- and what steps they can take to fix it.

There is no reason to show daemon errors to the user in this instance.

Before
<img width="408" alt="screen shot 2017-12-06 at 8 59 45 am" src="https://user-images.githubusercontent.com/5027235/33684304-ae7e6c34-da82-11e7-836a-9f2bb2b963cc.png">

After
<img width="416" alt="screen shot 2017-12-06 at 12 36 23 pm" src="https://user-images.githubusercontent.com/5027235/33684323-be4cedde-da82-11e7-8fba-4d4a4544e2a3.png">

