### PR TITLE
return null instead of empty string

### DIFF
--- a/src/renderer/component/subscribeButton/view.jsx
+++ b/src/renderer/component/subscribeButton/view.jsx
@@ -31,5 +31,5 @@ export default ({
         })}
       />
     </div>
-  ) : "";
+  ) : null;
 }


### PR DESCRIPTION
To fix "must return valid react element" error

I thought I could just return an empty string but I guess you need to return `null`