### PR TITLE
Fix channel link from subscriptions page

### DIFF
--- a/src/renderer/page/discover/view.jsx
+++ b/src/renderer/page/discover/view.jsx
@@ -184,7 +184,8 @@ export class FeaturedCategory extends React.PureComponent {
             <Link
               className="no-underline"
               label={category}
-              href={categoryLink}
+              navigate="/show"
+              navigateParams={{ uri: categoryLink }}
             />
           ) : (
             category

--- a/src/renderer/page/subscriptions/view.jsx
+++ b/src/renderer/page/subscriptions/view.jsx
@@ -88,7 +88,7 @@ export default class extends React.PureComponent<Props> {
                 return (
                   <FeaturedCategory
                     key={subscription.channelName}
-                    categoryLink={`lbry://${subscription.uri}`}
+                    categoryLink={subscription.uri}
                     category={subscription.channelName}
                     names={subscription.claims}
                   />


### PR DESCRIPTION
Need to use `navigate` for lbry links instead of `href`. Didn't notice any problems on mac but on windows it causes issues.