### PR TITLE
Style fixes

### DIFF
--- a/src/renderer/component/link/view.jsx
+++ b/src/renderer/component/link/view.jsx
@@ -8,6 +8,7 @@ const Link = props => {
     style,
     label,
     icon,
+    iconRight,
     button,
     disabled,
     children,
@@ -36,8 +37,9 @@ const Link = props => {
   } else {
     content = (
       <span {...("button" in props ? { className: "button__content" } : {})}>
-        {"icon" in props ? <Icon icon={icon} fixed={true} /> : null}
+        {icon ? <Icon icon={icon} fixed={true} /> : null}
         {label ? <span className="link-label">{label}</span> : null}
+        {iconRight ? <Icon icon={iconRight} fixed={true} /> : null}
       </span>
     );
   }

--- a/src/renderer/component/subscribeButton/view.jsx
+++ b/src/renderer/component/subscribeButton/view.jsx
@@ -23,6 +23,7 @@ export default ({
   return channelName && uri ? (
     <div className="card__actions">
       <Link
+        iconRight={isSubscribed ? "" : "at"}
         button={isSubscribed ? "alt" : "primary"}
         label={subscriptionLabel}
         onClick={() => subscriptionHandler({

--- a/src/renderer/modal/modalEmailCollection/view.jsx
+++ b/src/renderer/modal/modalEmailCollection/view.jsx
@@ -33,7 +33,7 @@ class ModalEmailCollection extends React.PureComponent {
       <Modal type="custom" isOpen={true} contentLabel="Email">
         <section>
           <h3 className="modal__header">
-            Can We <strike>Touch You</strike> Stay In Touch?
+            Can We Stay In Touch?
           </h3>
           {this.renderInner()}
         </section>

--- a/src/renderer/page/discover/view.jsx
+++ b/src/renderer/page/discover/view.jsx
@@ -182,7 +182,7 @@ export class FeaturedCategory extends React.PureComponent {
         <h3 className="card-row__header">
           {categoryLink ? (
             <Link
-              className="no-underline"
+              className="button-text no-underline"
               label={category}
               navigate="/show"
               navigateParams={{ uri: categoryLink }}

--- a/src/renderer/scss/component/_shapeshift.scss
+++ b/src/renderer/scss/component/_shapeshift.scss
@@ -13,7 +13,7 @@
 }
 
 .shapeshift__tx-info {
-  min-height: 55px;
+  min-height: 63px;
 }
 
 .shapeshift__deposit-address-wrapper {


### PR DESCRIPTION
Added the `@` icon to the subscribe button.
Make the links to channel on the subscriptions page more noticeable
Update copy on email modal

<img width="300" alt="screen shot 2017-12-10 at 1 26 31 pm" src="https://user-images.githubusercontent.com/16882830/33808118-fdd5b998-ddae-11e7-8fb1-0366cc59ed95.png">

Below is while hovering (mouse disappears during screenshots). The link style should probably just be props passed in, `linkStyle` or something generic like that. I will add that when we cleanup the Link component


<img width="300" alt="screen shot 2017-12-10 at 1 37 15 pm" src="https://user-images.githubusercontent.com/16882830/33808138-478bdd7e-ddaf-11e7-85cd-d8910aea37f6.png">




I like the joke in the email modal, but I think Reilly is right, more to lose than gain from it.
