### PR TITLE
Overwrite cmdtest when installing yarn

### DIFF
--- a/build/install_deps.sh
+++ b/build/install_deps.sh
@@ -99,7 +99,7 @@ if ! cmd_exists yarn; then
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | $SUDO apt-key add -
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | $SUDO tee /etc/apt/sources.list.d/yarn.list
     $SUDO apt-get update
-    $SUDO apt-get install yarn
+    $SUDO apt-get -o Dpkg::Options::="--force-overwrite" install yarn
   elif $OSX; then
     brew install yarn
   else


### PR DESCRIPTION
Update `install_deps.sh` script to overwrite `cmdtest` for resolving [this error](https://github.com/yarnpkg/yarn/issues/2821) that happens on Ubuntu 17.04. See note on [Debian/Ubuntu Linux section](https://yarnpkg.com/lang/en/docs/install/#linux-tab).