### PR TITLE
Reworked abandon to not be depenedent on txn list

### DIFF
--- a/src/renderer/redux/actions/app.js
+++ b/src/renderer/redux/actions/app.js
@@ -9,7 +9,7 @@ import {
   selectRemoteVersion,
 } from "redux/selectors/app";
 import { doFetchDaemonSettings } from "redux/actions/settings";
-import { doBalanceSubscribe, doFetchTransactions } from "redux/actions/wallet";
+import { doBalanceSubscribe } from "redux/actions/wallet";
 import { doAuthenticate } from "redux/actions/user";
 import { doFetchFileInfosAndPublishedClaims } from "redux/actions/file_info";
 import * as modals from "constants/modal_types";
@@ -222,7 +222,6 @@ export function doDaemonReady() {
     dispatch(doBalanceSubscribe());
     dispatch(doFetchFileInfosAndPublishedClaims());
     dispatch(doFetchRewardedContent());
-    dispatch(doFetchTransactions(false));
     if (!selectIsUpgradeSkipped(state)) {
       dispatch(doCheckUpgradeAvailable());
     }

--- a/src/renderer/redux/actions/content.js
+++ b/src/renderer/redux/actions/content.js
@@ -4,7 +4,8 @@ import lbry from "lbry";
 import lbryio from "lbryio";
 import lbryuri from "lbryuri";
 import { makeSelectClientSetting } from "redux/selectors/settings";
-import { selectBalance, selectTransactionItems } from "redux/selectors/wallet";
+import { selectMyClaimsRaw } from "redux/selectors/claims";
+import { selectBalance } from "redux/selectors/wallet";
 import {
   makeSelectFileInfoForUri,
   selectDownloadingByOutpoint,
@@ -288,7 +289,9 @@ export function doLoadVideo(uri) {
         });
         dispatch(
           doAlertError(
-            `Failed to download ${uri}, please try again. If this problem persists, visit https://lbry.io/faq/support for support.`
+            `Failed to download ${
+              uri
+            }, please try again. If this problem persists, visit https://lbry.io/faq/support for support.`
           )
         );
       });
@@ -503,8 +506,8 @@ export function doPublish(params) {
 export function doAbandonClaim(txid, nout) {
   return function(dispatch, getState) {
     const state = getState();
-    const transactionItems = selectTransactionItems(state);
-    const { claim_id: claimId, claim_name: name } = transactionItems.find(
+    const myClaims = selectMyClaimsRaw(state);
+    const { claim_id: claimId, name: name } = myClaims.find(
       claim => claim.txid == txid && claim.nout == nout
     );
 

--- a/src/renderer/redux/actions/wallet.js
+++ b/src/renderer/redux/actions/wallet.js
@@ -29,13 +29,13 @@ export function doBalanceSubscribe() {
   };
 }
 
-export function doFetchTransactions(fetch_tip_info = true) {
+export function doFetchTransactions() {
   return function(dispatch, getState) {
     dispatch({
       type: types.FETCH_TRANSACTIONS_STARTED,
     });
 
-    lbry.transaction_list({ include_tip_info: fetch_tip_info }).then(results => {
+    lbry.transaction_list({ include_tip_info: true }).then(results => {
       dispatch({
         type: types.FETCH_TRANSACTIONS_COMPLETED,
         data: {


### PR DESCRIPTION
@kauffj, so this PR removes the dependency of abandon_claim on transaction list. Now it fetches the data from myClaims instead. @tzarebczan and I have given this a whirl and so far the edge cases work too.