### PR TITLE
Add Help button on top row of app

### DIFF
--- a/src/renderer/component/header/view.jsx
+++ b/src/renderer/component/header/view.jsx
@@ -86,6 +86,14 @@ export const Header = props => {
           title={__("Settings")}
         />
       </div>
+      <div className="header__item">
+        <Link
+          onClick={() => navigate("/help")}
+          button="alt button--flat"
+          icon="icon-question-circle"
+          title={__("Help")}
+        />
+      </div>
       {isUpgradeAvailable && (
         <Link
           onClick={() => downloadUpgrade()}


### PR DESCRIPTION
Added a "Help" button/link to the right edge of the header.

Closes #809.