### PR TITLE
Re-introduce build dir / dist dir option for isolated build environments.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "dev": "electron-webpack dev",
     "compile": "electron-webpack && yarn extract-langs",
     "build": "yarn compile && electron-builder build",
+    "build:dir": "yarn build -- --dir -c.compression=store -c.mac.identity=null",
     "postinstall": "electron-builder install-app-deps",
     "precommit": "lint-staged",
     "lint": "eslint 'src/**/*.{js,jsx}' --fix",


### PR DESCRIPTION
This PR re-introduces the functionality for building lbry-app with a directory target. This is important for isolated build environments like [solbuild](https://github.com/solus-project/solbuild) (used for Solus), where build and install directories are different (and the contents of install dir are used in a final binary package) and thus necessitate being able to have unpackaged assets be placed in a directory relative to the build location, so instructions may be performed on those assets.

Note: This patch has already been tested with [this commit to our package repo](https://dev.solus-project.com/R3654:0770e2ea0a5b5e9305cb988a0b089ddd785c4e06) and validated locally.