### PR TITLE
Fix validity of Linux .desktop file

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -39,7 +39,7 @@
   ],
   "linux": {
     "target": "deb",
-    "category": "Video",
+    "category": "Video;AudioVideo;",
     "desktop": {
       "MimeType": "x-scheme-handler/lbry",
       "Exec": "/opt/LBRY/lbry %U"


### PR DESCRIPTION
Per the menu spec https://standards.freedesktop.org/menu-spec/latest/apa.html if you specify Video you also need to specify the AudioVideo category.