### PR TITLE
Enable play button after clicking download

### DIFF
--- a/src/renderer/component/video/internal/play-button.jsx
+++ b/src/renderer/component/video/internal/play-button.jsx
@@ -23,7 +23,7 @@ class VideoPlayButton extends React.PureComponent {
   }
 
   render() {
-    const { button, label, isLoading, fileInfo, mediaType } = this.props;
+    const { button, label, fileInfo, mediaType } = this.props;
 
     /*
      title={
@@ -33,13 +33,12 @@ class VideoPlayButton extends React.PureComponent {
      }
      */
 
-    const disabled = isLoading || fileInfo === undefined;
     const icon = ['audio', 'video'].indexOf(mediaType) !== -1 ? 'icon-play' : 'icon-folder-o';
 
     return (
       <Link
         button={button || null}
-        disabled={disabled}
+        disabled={fileInfo === undefined}
         label={label || ''}
         className="video__play-button"
         icon={icon}


### PR DESCRIPTION
Fixes #906 by ignoring the isLoading prop when determining the disabled state of the button.