### PR TITLE
v0.19 daemon - remove include_tip_info parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Web UI version numbers should always match the corresponding version of LBRY App
   *
 
 ### Changed
-  *
+  * Remove include_tip_info parameter from transaction_list call ([#1019](https://github.com/lbryio/lbry-app/issues/1019))
   *
 
 ### Fixed

--- a/src/renderer/redux/actions/wallet.js
+++ b/src/renderer/redux/actions/wallet.js
@@ -35,7 +35,7 @@ export function doFetchTransactions() {
       type: ACTIONS.FETCH_TRANSACTIONS_STARTED,
     });
 
-    Lbry.transaction_list({ include_tip_info: true }).then(results => {
+    Lbry.transaction_list().then(results => {
       dispatch({
         type: ACTIONS.FETCH_TRANSACTIONS_COMPLETED,
         data: {


### PR DESCRIPTION
The v19 daemon transaction_list call no longer requires the include_tip_info parameter 

```
2018-02-15 12:22:48,516 WARNING  lbrynet.daemon.auth.server:350: Extraneous parameters for transaction_list command: include_tip_info
2018-02-15 12:22:48,516 WARNING  lbrynet.daemon.auth.server:228: error processing api request: Extraneous parameters for transaction_list command: include_tip_info
```