### PR TITLE
Reduce typing timeout to trigger search

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "mixpanel-browser": "^2.17.1",
     "moment": "^2.20.1",
     "npm": "^5.5.1",
+    "prop-types": "^15.6.1",
     "qrcode.react": "^0.7.2",
     "rc-progress": "^2.0.6",
     "react": "^16.2.0",

--- a/src/renderer/component/wunderbar/index.js
+++ b/src/renderer/component/wunderbar/index.js
@@ -2,11 +2,13 @@ import { connect } from 'react-redux';
 
 import { normalizeURI } from 'lbryURI';
 import { doNavigate } from 'redux/actions/navigation';
+import { selectCurrentPath } from 'redux/selectors/navigation';
 import { selectWunderBarAddress, selectWunderBarIcon } from 'redux/selectors/search';
 import Wunderbar from './view';
 
 const select = state => ({
   address: selectWunderBarAddress(state),
+  currentPath: selectCurrentPath(state),
   icon: selectWunderBarIcon(state),
 });
 

--- a/src/renderer/component/wunderbar/index.js
+++ b/src/renderer/component/wunderbar/index.js
@@ -1,8 +1,8 @@
-import React from 'react';
 import { connect } from 'react-redux';
-import { normalizeURI } from 'lbryURI.js';
-import { selectWunderBarAddress, selectWunderBarIcon } from 'redux/selectors/search';
+
+import { normalizeURI } from 'lbryURI';
 import { doNavigate } from 'redux/actions/navigation';
+import { selectWunderBarAddress, selectWunderBarIcon } from 'redux/selectors/search';
 import Wunderbar from './view';
 
 const select = state => ({

--- a/src/renderer/component/wunderbar/view.jsx
+++ b/src/renderer/component/wunderbar/view.jsx
@@ -1,5 +1,6 @@
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
+
 import { normalizeURI } from 'lbryURI';
 import Icon from 'component/icon';
 import { parseQueryParams } from 'util/query_params';
@@ -8,72 +9,91 @@ class WunderBar extends React.PureComponent {
   static TYPING_TIMEOUT = 800;
 
   static propTypes = {
+    address: PropTypes.string.isRequired,
+    icon: PropTypes.string.isRequired,
     onSearch: PropTypes.func.isRequired,
-    onSubmit: PropTypes.func.isRequired,
   };
 
   constructor(props) {
     super(props);
-    this._userTypingTimer = null;
-    this._isSearchDispatchPending = false;
-    this._input = null;
-    this._stateBeforeSearch = null;
-    this._resetOnNextBlur = true;
+
+    this.inputField = null;
+    this.isSearchDispatchPending = false;
+    this.resetOnNextBlur = true;
+    this.stateBeforeSearch = null;
+    this.userTypingTimer = null;
+
+    this.onBlur = this.onBlur.bind(this);
     this.onChange = this.onChange.bind(this);
     this.onFocus = this.onFocus.bind(this);
-    this.onBlur = this.onBlur.bind(this);
     this.onKeyPress = this.onKeyPress.bind(this);
     this.onReceiveRef = this.onReceiveRef.bind(this);
+
     this.state = {
       address: this.props.address,
       icon: this.props.icon,
     };
   }
 
-  componentWillUnmount() {
-    if (this.userTypingTimer) {
-      clearTimeout(this._userTypingTimer);
-    }
-  }
-
-  onChange(event) {
-    if (this._userTypingTimer) {
-      clearTimeout(this._userTypingTimer);
-    }
-
-    this.setState({ address: event.target.value });
-
-    this._isSearchDispatchPending = true;
-
-    const searchQuery = event.target.value;
-
-    this._userTypingTimer = setTimeout(() => {
-      const hasQuery = searchQuery.length === 0;
-      this._resetOnNextBlur = hasQuery;
-      this._isSearchDispatchPending = false;
-      if (searchQuery) {
-        this.props.onSearch(searchQuery.trim());
-      }
-    }, WunderBar.TYPING_TIMEOUT); // 800ms delay, tweak for faster/slower
-  }
-
   componentWillReceiveProps(nextProps) {
-    if (
-      nextProps.viewingPage !== this.props.viewingPage ||
-      nextProps.address != this.props.address
-    ) {
+    if (nextProps.address !== this.props.address) {
       this.setState({ address: nextProps.address, icon: nextProps.icon });
     }
   }
 
+  componentDidUpdate() {
+    if (this.inputField) {
+      const start = this.inputField.selectionStart;
+      const end = this.inputField.selectionEnd;
+
+      this.inputField.value = this.state.address; // This causes cursor to go to end of input.
+      this.inputField.setSelectionRange(start, end);
+
+      if (this.focusPending) {
+        this.inputField.select();
+        this.focusPending = false;
+      }
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.userTypingTimer) {
+      clearTimeout(this.userTypingTimer);
+    }
+  }
+
+  onChange(event) {
+    if (this.userTypingTimer) {
+      clearTimeout(this.userTypingTimer);
+    }
+
+    this.setState({ address: event.target.value });
+
+    this.isSearchDispatchPending = true;
+
+    const searchQuery = event.target.value;
+
+    this.userTypingTimer = setTimeout(() => {
+      const hasQuery = searchQuery.length === 0;
+      this.resetOnNextBlur = hasQuery;
+      this.isSearchDispatchPending = false;
+
+      if (searchQuery) {
+        this.props.onSearch(searchQuery.trim());
+      }
+    }, WunderBar.TYPING_TIMEOUT);
+  }
+
   onFocus() {
-    this._stateBeforeSearch = this.state;
+    this.stateBeforeSearch = this.state;
+
     const newState = {
       icon: 'icon-search',
       isActive: true,
     };
 
-    this._focusPending = true;
+    this.focusPending = true;
+
     // below is hacking, improved when we have proper routing
     if (!this.state.address.startsWith('lbry://') && this.state.icon !== 'icon-search') {
       // onFocus, if they are not on an exact URL or a search page, clear the bar
@@ -83,55 +103,38 @@ class WunderBar extends React.PureComponent {
   }
 
   onBlur() {
-    if (this._isSearchDispatchPending) {
+    if (this.isSearchDispatchPending) {
       setTimeout(() => {
         this.onBlur();
       }, WunderBar.TYPING_TIMEOUT + 1);
     } else {
       const commonState = { isActive: false };
-      if (this._resetOnNextBlur) {
-        this.setState(Object.assign({}, this._stateBeforeSearch, commonState));
-        this._input.value = this.state.address;
+      if (this.resetOnNextBlur) {
+        this.setState(Object.assign({}, this.stateBeforeSearch, commonState));
+        this.inputField.value = this.state.address;
       } else {
-        this._resetOnNextBlur = true;
-        this._stateBeforeSearch = this.state;
+        this.resetOnNextBlur = true;
+        this.stateBeforeSearch = this.state;
         this.setState(commonState);
       }
     }
   }
 
-  componentDidUpdate() {
-    if (this._input) {
-      const start = this._input.selectionStart,
-        end = this._input.selectionEnd;
-
-      this._input.value = this.state.address; // this causes cursor to go to end of input
-
-      this._input.setSelectionRange(start, end);
-
-      if (this._focusPending) {
-        this._input.select();
-        this._focusPending = false;
-      }
-    }
-  }
-
   onKeyPress(event) {
-    if (event.charCode == 13 && this._input.value) {
-      let uri = null,
-        method = 'onSubmit',
-        extraParams = {};
+    if (event.charCode === 13 && this.inputField.value) {
+      let extraParams = {};
+      let method = 'onSubmit';
+      let uri = null;
 
-      this._resetOnNextBlur = false;
-      clearTimeout(this._userTypingTimer);
+      this.resetOnNextBlur = false;
+      clearTimeout(this.userTypingTimer);
 
-      const parts = this._input.value.trim().split('?');
+      const parts = this.inputField.value.trim().split('?');
       const value = parts.shift();
       if (parts.length > 0) extraParams = parseQueryParams(parts.join(''));
 
       try {
         uri = normalizeURI(value);
-        this.setState({ value: uri });
       } catch (error) {
         // then it's not a valid URL, so let's search
         uri = value;
@@ -139,12 +142,12 @@ class WunderBar extends React.PureComponent {
       }
 
       this.props[method](uri, extraParams);
-      this._input.blur();
+      this.inputField.blur();
     }
   }
 
   onReceiveRef(ref) {
-    this._input = ref;
+    this.inputField = ref;
   }
 
   render() {
@@ -153,14 +156,14 @@ class WunderBar extends React.PureComponent {
         {this.state.icon ? <Icon fixed icon={this.state.icon} /> : ''}
         <input
           className="wunderbar__input"
-          type="search"
-          ref={this.onReceiveRef}
-          onFocus={this.onFocus}
           onBlur={this.onBlur}
           onChange={this.onChange}
+          onFocus={this.onFocus}
           onKeyPress={this.onKeyPress}
-          value={this.state.address}
           placeholder={__('Find videos, music, games, and more')}
+          ref={this.onReceiveRef}
+          type="search"
+          value={this.state.address}
         />
       </div>
     );

--- a/src/renderer/component/wunderbar/view.jsx
+++ b/src/renderer/component/wunderbar/view.jsx
@@ -10,6 +10,7 @@ class WunderBar extends React.PureComponent {
 
   static propTypes = {
     address: PropTypes.string.isRequired,
+    currentPath: PropTypes.string.isRequired,
     icon: PropTypes.string.isRequired,
     onSearch: PropTypes.func.isRequired,
   };
@@ -72,6 +73,11 @@ class WunderBar extends React.PureComponent {
     this.isSearchDispatchPending = true;
 
     const searchQuery = event.target.value;
+
+    // If we are not on the search page yet, navigate to it
+    if (!this.props.currentPath.startsWith('/search?')) {
+      this.props.onSearch(searchQuery.trim());
+    }
 
     this.userTypingTimer = setTimeout(() => {
       const hasQuery = searchQuery.length === 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7074,6 +7074,14 @@ prop-types@^15.5.1, prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+prop-types@^15.6.1:
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"


### PR DESCRIPTION
This would solve #1052.

There are two commits. The first one fixes various linter issues in the files related to the actual fix, which is in the second commit.

The fix is simply to navigate immediately to the search page, if the user is not there yet. This does not change the existing 800ms typing delay between searches, which remains tweakable in the code.