### PR TITLE
start search quickly if search dispatch was pending

### DIFF
--- a/src/renderer/component/wunderbar/view.jsx
+++ b/src/renderer/component/wunderbar/view.jsx
@@ -6,6 +6,7 @@ import { parseQueryParams } from 'util/query_params';
 
 class WunderBar extends React.PureComponent {
   static TYPING_TIMEOUT = 800;
+  static START_SEARCH = 100;
 
   static propTypes = {
     onSearch: PropTypes.func.isRequired,
@@ -43,6 +44,8 @@ class WunderBar extends React.PureComponent {
 
     this.setState({ address: event.target.value });
 
+    const searchDispatchWasPending = this._isSearchDispatchPending;
+
     this._isSearchDispatchPending = true;
 
     const searchQuery = event.target.value;
@@ -54,7 +57,8 @@ class WunderBar extends React.PureComponent {
       if (searchQuery) {
         this.props.onSearch(searchQuery.trim());
       }
-    }, WunderBar.TYPING_TIMEOUT); // 800ms delay, tweak for faster/slower
+    },
+    searchDispatchWasPending ? WunderBar.TYPING_TIMEOUT : WunderBar.START_SEARCH);
   }
 
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
#1052 

This adds a new constant `START_SEARCH` to WunderBar. Before there was only `TYPING_TIMEOUT`. Now the SetTimeout call uses `TYPING_TIMEOUT` for delay time (800ms) if there was a search dispatch pending, so it won't load more requests than it already was, but if there was no search dispatch pending it uses `START_SEARCH` for delay time (100ms).

It works like I think it should based on reading the issue