### PR TITLE
Re-poll doFetchFeaturedUris every so often

### DIFF
--- a/src/renderer/redux/actions/content.js
+++ b/src/renderer/redux/actions/content.js
@@ -71,6 +71,13 @@ export function doResolveUri(uri) {
 
 export function doFetchFeaturedUris() {
   return dispatch => {
+    dispatch(doFetchFeaturedUrisNow());
+    setInterval(() => dispatch(doFetchFeaturedUrisNow()), 40000);
+  }
+}
+
+export function doFetchFeaturedUrisNow() {
+  return dispatch => {
     dispatch({
       type: ACTIONS.FETCH_FEATURED_CONTENT_STARTED,
     });


### PR DESCRIPTION
issue #1048 

I copied the way `doBalanceSubscribe` and `doUpdateBalance` work together in the form of `doFetchFeaturedUris` and `doFetchFeaturedUrisNow`. Every 40 seconds (will be 1 hour once it works properly) this calls the action and fetches the correct data, but if you leave the Discover page and come back, it starts a new loop of calling the action every 40 seconds. I've a tried a few ways of naming the setInterval so I can clearInterval but haven't got it working properly yet. I can think of how I'd do it with new state properties and reducers but am trying to avoid that.

I am digging deeper into this and submitting the PR to discuss the code