### PR TITLE
Remove app side balance checks

### DIFF
--- a/src/renderer/component/publishForm/internal/channelSection.jsx
+++ b/src/renderer/component/publishForm/internal/channelSection.jsx
@@ -57,12 +57,12 @@ class ChannelSection extends React.PureComponent {
 
       return;
     }
-    if (newChannelBid == 0) {
+    if (newChannelBid === 0) {
       this.refs.newChannelName.showError(__('Bid value must be greater than 0.'));
 
       return;
     }
-        if (newChannelBid == balance) {
+        if (newChannelBid === balance) {
       this.refs.newChannelName.showError(__('Please decrease your bid to account for transaction fees.'));
 
       return;

--- a/src/renderer/component/publishForm/internal/channelSection.jsx
+++ b/src/renderer/component/publishForm/internal/channelSection.jsx
@@ -57,6 +57,16 @@ class ChannelSection extends React.PureComponent {
 
       return;
     }
+    if (newChannelBid == 0) {
+      this.refs.newChannelName.showError(__('Bid value must be greater than 0.'));
+
+      return;
+    }
+        if (newChannelBid == balance) {
+      this.refs.newChannelName.showError(__('Please decrease your bid to account for transaction fees.'));
+
+      return;
+    }
 
     this.setState({
       creatingChannel: true,

--- a/src/renderer/component/publishForm/view.jsx
+++ b/src/renderer/component/publishForm/view.jsx
@@ -61,15 +61,6 @@ class PublishForm extends React.PureComponent {
   }
 
   handleSubmit() {
-    const { balance } = this.props;
-    const { bid } = this.state;
-
-    if (bid > balance) {
-      this.handlePublishError({ message: 'insufficient funds' });
-
-      return;
-    }
-
     this.setState({
       submitting: true,
     });


### PR DESCRIPTION
Adding 2 checks to channel bid (equal to balance, and equal to 0) based on https://github.com/lbryio/lbry-app/pull/794 because the error messages don't make it from the daemon, so will these in place.

Removed publish side check, error message from the daemon are now more accurate. 

Tested this out locally. 