### PR TITLE
fix: app quitting when accepting update

### DIFF
--- a/src/main/createWindow.js
+++ b/src/main/createWindow.js
@@ -49,7 +49,7 @@ export default appState => {
   setupContextMenu(window);
 
   window.on('close', event => {
-    if (!appState.isQuitting) {
+    if (!appState.isQuitting && !appState.autoUpdateAccepted) {
       event.preventDefault();
       window.hide();
     }

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -19,9 +19,6 @@ autoUpdater.autoDownload = true;
 // it will still install on shutdown.
 let autoUpdateDownloaded = false;
 
-// Keeps track of whether the user has accepted an auto-update through the interface.
-let autoUpdateAccepted = false;
-
 // This is used to keep track of whether we are showing the special dialog
 // that we show on Windows after you decline an upgrade and close the app later.
 let showingAutoUpdateCloseAlert = false;
@@ -88,7 +85,7 @@ app.on('will-quit', event => {
   if (
     process.platform === 'win32' &&
     autoUpdateDownloaded &&
-    !autoUpdateAccepted &&
+    !appState.autoUpdateAccepted &&
     !showingAutoUpdateCloseAlert
   ) {
     // We're on Win and have an update downloaded, but the user declined it (or closed
@@ -152,7 +149,7 @@ autoUpdater.on('update-downloaded', () => {
 });
 
 ipcMain.on('autoUpdateAccepted', () => {
-  autoUpdateAccepted = true;
+  appState.autoUpdateAccepted = true;
   autoUpdater.quitAndInstall();
 });
 


### PR DESCRIPTION
This fixes #1111. The app wouldn't completely quit after an update was downloaded and the user has pressed "USE IT NOW".