### PR TITLE
Include updated channels in results

### DIFF
--- a/src/renderer/redux/reducers/claims.js
+++ b/src/renderer/redux/reducers/claims.js
@@ -43,7 +43,7 @@ reducers[ACTIONS.FETCH_CLAIM_LIST_MINE_COMPLETED] = (state, action) => {
   const byId = Object.assign({}, state.byId);
   const pendingById = Object.assign({}, state.pendingById);
 
-  claims.filter(claim => claim.category && claim.category.match(/claim/)).forEach(claim => {
+  claims.filter(claim => claim.category && (claim.category.match(/claim/) || claim.category.match(/update/))).forEach(claim => {
     byId[claim.claim_id] = claim;
 
     const pending = Object.values(pendingById).find(


### PR DESCRIPTION
Channels may be updated with new bids and will appear as "update" in channel_list. This would also occur if claims were sent from one user to another (i.e. us transferring a channel to a youtuber).