### PR TITLE
Add go to page navigation to channel pagination options

### DIFF
--- a/src/renderer/component/common/form-components/form-row.jsx
+++ b/src/renderer/component/common/form-components/form-row.jsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import classnames from 'classnames';
 
 type Props = {
+  centered?: boolean,
   children: React.Node,
   padded?: boolean,
   verticallyCentered?: boolean,
@@ -15,12 +16,13 @@ export class FormRow extends React.PureComponent<Props> {
   };
 
   render() {
-    const { children, padded, verticallyCentered } = this.props;
+    const { centered, children, padded, verticallyCentered } = this.props;
     return (
       <div
         className={classnames('form-row', {
+          'form-row--centered': centered,
           'form-row--padded': padded,
-          'form-row--centered': verticallyCentered,
+          'form-row--vertically-centered': verticallyCentered,
         })}
       >
         {children}

--- a/src/renderer/page/channel/view.jsx
+++ b/src/renderer/page/channel/view.jsx
@@ -1,8 +1,7 @@
 // @flow
 import React from 'react';
-import { buildURI } from 'lbryURI';
 import BusyIndicator from 'component/common/busy-indicator';
-import FileTile from 'component/fileTile';
+import { FormField, FormRow } from 'component/common/form';
 import ReactPaginate from 'react-paginate';
 import Button from 'component/button';
 import SubscribeButton from 'component/subscribeButton';
@@ -24,8 +23,6 @@ type Props = {
   fetchClaims: (string, number) => void,
   fetchClaimCount: string => void,
   navigate: (string, {}) => void,
-  doChannelSubscribe: string => void,
-  doChannelUnsubscribe: string => void,
   openModal: (string, {}) => void,
 };
 
@@ -38,12 +35,12 @@ class ChannelPage extends React.PureComponent<Props> {
   }
 
   componentWillReceiveProps(nextProps: Props) {
-    const { page, uri, fetching, fetchClaims, fetchClaimCount } = this.props;
+    const { page, uri, fetchClaims, fetchClaimCount } = this.props;
 
     if (nextProps.page && page !== nextProps.page) {
       fetchClaims(nextProps.uri, nextProps.page);
     }
-    if (nextProps.uri != uri) {
+    if (nextProps.uri !== uri) {
       fetchClaimCount(uri);
     }
   }
@@ -55,10 +52,17 @@ class ChannelPage extends React.PureComponent<Props> {
     this.props.navigate('/show', newParams);
   }
 
+  paginate(e, totalPages) {
+    // Change page if enter was pressed, and the given page is between
+    // the first and the last.
+    if (e.keyCode === 13 && e.target.value > 0 && e.target.value <= totalPages) {
+      this.changePage(e.target.value);
+    }
+  }
+
   render() {
     const { fetching, claimsInChannel, claim, uri, page, totalPages, openModal } = this.props;
-    const { name, claim_id: claimId } = claim;
-    const subscriptionUri = buildURI({ channelName: name, claimId }, false);
+    const { name } = claim;
 
     let contentList;
     if (fetching) {
@@ -89,21 +93,30 @@ class ChannelPage extends React.PureComponent<Props> {
         <section>{contentList}</section>
         {(!fetching || (claimsInChannel && claimsInChannel.length)) &&
           totalPages > 1 && (
-            <ReactPaginate
-              pageCount={totalPages}
-              pageRangeDisplayed={2}
-              previousLabel="‹"
-              nextLabel="›"
-              activeClassName="pagination__item--selected"
-              pageClassName="pagination__item"
-              previousClassName="pagination__item pagination__item--previous"
-              nextClassName="pagination__item pagination__item--next"
-              breakClassName="pagination__item pagination__item--break"
-              marginPagesDisplayed={2}
-              onPageChange={e => this.changePage(e.selected + 1)}
-              initialPage={parseInt(page - 1)}
-              containerClassName="pagination"
-            />
+            <FormRow verticallyCentered centered>
+              <ReactPaginate
+                pageCount={totalPages}
+                pageRangeDisplayed={2}
+                previousLabel="‹"
+                nextLabel="›"
+                activeClassName="pagination__item--selected"
+                pageClassName="pagination__item"
+                previousClassName="pagination__item pagination__item--previous"
+                nextClassName="pagination__item pagination__item--next"
+                breakClassName="pagination__item pagination__item--break"
+                marginPagesDisplayed={2}
+                onPageChange={e => this.changePage(e.selected + 1)}
+                initialPage={parseInt(page - 1, 10)}
+                containerClassName="pagination"
+              />
+
+              <FormField
+                className="paginate-channel"
+                onKeyUp={e => this.paginate(e, totalPages)}
+                prefix={__('Go to page:')}
+                type="text"
+              />
+            </FormRow>
           )}
       </Page>
     );

--- a/src/renderer/scss/component/_form-field.scss
+++ b/src/renderer/scss/component/_form-field.scss
@@ -7,11 +7,15 @@
     padding-left: $spacing-vertical;
   }
 
+  &.form-row--centered {
+    justify-content: center;
+  }
+
   &.form-row--padded {
     padding-top: $spacing-vertical * 2/3;
   }
 
-  &.form-row--centered {
+  &.form-row--vertically-centered {
     align-items: center;
   }
 
@@ -42,6 +46,10 @@
   input[type='checkbox'],
   input[type='radio'] {
     margin-top: 5px;
+  }
+
+  input.paginate-channel {
+    width: 35px;
   }
 }
 

--- a/src/renderer/scss/component/_pagination.scss
+++ b/src/renderer/scss/component/_pagination.scss
@@ -1,7 +1,6 @@
 .pagination {
   display: block;
   padding: 0;
-  margin: 0 auto;
   text-align: center;
 }
 


### PR DESCRIPTION
This would close #711.

The component used for pagination (react-navigate) doesn't offer customisation options, so a separate control for choosing the target page is needed. The implementation is such that the user would enter a page number and presses the enter key.

<img width="902" alt="unfocused" src="https://user-images.githubusercontent.com/16205520/37783164-747059ac-2dfd-11e8-87f0-2a5e0598599b.png">

<img width="900" alt="focused" src="https://user-images.githubusercontent.com/16205520/37783169-78b74a66-2dfd-11e8-9309-1ffd9f5aa292.png">