### PR TITLE
Add release notes to upgrade modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "LBRY",
-  "version": "0.21.2",
+  "version": "0.20.0",
   "description": "A browser for the LBRY network, a digital marketplace controlled by its users.",
   "keywords": [
     "lbry"

--- a/src/renderer/modal/modalAutoUpdateDownloaded/view.jsx
+++ b/src/renderer/modal/modalAutoUpdateDownloaded/view.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
+import { ipcRenderer } from 'electron';
 import { Modal } from 'modal/modal';
-import { Line } from 'rc-progress';
 import Button from 'component/button';
-
-const { ipcRenderer } = require('electron');
 
 class ModalAutoUpdateDownloaded extends React.PureComponent {
   render() {
@@ -34,7 +32,10 @@ class ModalAutoUpdateDownloaded extends React.PureComponent {
           </p>
           <p className="meta text-center">
             {__('Want to know what has changed?')} See the{' '}
-            <Button label={__('release notes')} href="https://github.com/lbryio/lbry-app/releases" />.
+            <Button
+              label={__('release notes')}
+              href="https://github.com/lbryio/lbry-app/releases"
+            />.
           </p>
         </section>
       </Modal>

--- a/src/renderer/modal/modalAutoUpdateDownloaded/view.jsx
+++ b/src/renderer/modal/modalAutoUpdateDownloaded/view.jsx
@@ -32,6 +32,10 @@ class ModalAutoUpdateDownloaded extends React.PureComponent {
               'A new version of LBRY has been released, downloaded, and is ready for you to use pending a restart.'
             )}
           </p>
+          <p className="meta text-center">
+            {__('Want to know what has changed?')} See the{' '}
+            <Button label={__('release notes')} href="https://github.com/lbryio/lbry-app/releases" />.
+          </p>
         </section>
       </Modal>
     );


### PR DESCRIPTION
Adding back in release notes based on the old upgrade modal: https://github.com/lbryio/lbry-app/blob/master/src/renderer/modal/modalUpgrade/view.jsx#L25

I did this based on inspection, not sure how it will look. Main difference here is that it's all in a section.