### PR TITLE
Obscure NSFW content title

### DIFF
--- a/src/renderer/component/fileCard/view.jsx
+++ b/src/renderer/component/fileCard/view.jsx
@@ -1,19 +1,17 @@
 // @flow
 import * as React from 'react';
 import { normalizeURI } from 'lbryURI';
+import Button from 'component/button';
 import CardMedia from 'component/cardMedia';
 import TruncatedText from 'component/common/truncated-text';
 import Icon from 'component/common/icon';
 import FilePrice from 'component/filePrice';
 import UriIndicator from 'component/uriIndicator';
-import NsfwOverlay from 'component/nsfwOverlay';
 import * as icons from 'constants/icons';
 import classnames from 'classnames';
 
 // TODO: iron these out
 type Props = {
-  isResolvingUri: boolean,
-  resolveUri: string => void,
   uri: string,
   claim: ?{ claim_id: string },
   fileInfo: ?{},
@@ -78,22 +76,41 @@ class FileCard extends React.PureComponent<Props> {
         <CardMedia nsfw={shouldObscureNsfw} thumbnail={thumbnail} />
         <div className="card-media__internal-links">{showPrice && <FilePrice uri={uri} />}</div>
 
-        <div className="card__title-identity">
-          <div className="card__title--small">
-            <TruncatedText lines={3}>{title}</TruncatedText>
+        {shouldObscureNsfw ? (
+          <div className="card__title-identity">
+            <div className="card__title--small">
+              <TruncatedText lines={3}>
+                {__('This content is obscured because it is NSFW. You can change this in ')}
+                <Button
+                  button="link"
+                  label={__('Settings.')}
+                  onClick={e => {
+                    // Don't propagate to the onClick handler of parent element
+                    e.stopPropagation();
+                    navigate('/settings');
+                  }}
+                />
+              </TruncatedText>
+            </div>
           </div>
-          <div className="card__subtitle card__subtitle--file-info">
-            {pending ? (
-              <div>Pending...</div>
-            ) : (
-              <React.Fragment>
-                <UriIndicator uri={uri} link />
-                {isRewardContent && <Icon icon={icons.FEATURED} />}
-                {fileInfo && <Icon icon={icons.LOCAL} />}
-              </React.Fragment>
-            )}
+        ) : (
+          <div className="card__title-identity">
+            <div className="card__title--small">
+              <TruncatedText lines={3}>{title}</TruncatedText>
+            </div>
+            <div className="card__subtitle card__subtitle--file-info">
+              {pending ? (
+                <div>Pending...</div>
+              ) : (
+                <React.Fragment>
+                  <UriIndicator uri={uri} link />
+                  {isRewardContent && <Icon icon={icons.FEATURED} />}
+                  {fileInfo && <Icon icon={icons.LOCAL} />}
+                </React.Fragment>
+              )}
+            </div>
           </div>
-        </div>
+        )}
       </section>
     );
     /* eslint-enable jsx-a11y/click-events-have-key-events */


### PR DESCRIPTION
If NSFW content is not enabled in settings, thumbnails for NSFW content are obscured, but the file titles are not. This change hides the title information, so no (likely) NSFW text (in the title or username) is shown either. The implementation before redesign actually blurred both the image and the text.

It looks like this now:

<img width="679" alt="screen shot 2018-04-01 at 13 33 56" src="https://user-images.githubusercontent.com/16205520/38172244-60bf3840-35b1-11e8-82fc-456329ea4018.png">
