### PR TITLE
Unset form field input height to make it scale

### DIFF
--- a/src/renderer/scss/component/_form-field.scss
+++ b/src/renderer/scss/component/_form-field.scss
@@ -41,17 +41,19 @@
 .form-field__input {
   display: flex;
   padding-top: $spacing-vertical / 3;
-  height: 36px;
 
-  input[type='checkbox'],
+  input[type='checkbox'] {
+    margin-top: 4px;
+  }
+
   input[type='radio'] {
-    margin-top: 5px;
+    margin-top: 2px;
   }
 
   input.paginate-channel {
     width: 35px;
   }
-    
+
   &.form-field--auto-height {
     height: auto;
   }


### PR DESCRIPTION
This would close #1228.

The problem is that the input div height was fixed to 36px, which prevented it to wrap the containing text to additional lines. This simple change enables wrapping in practice.

It looks like this:

<img width="698" alt="screen shot 2018-04-01 at 13 49 17" src="https://user-images.githubusercontent.com/16205520/38172351-84024b88-35b3-11e8-986e-272da73402fc.png">
