### PR TITLE
Fix black screen on macOS after maximizing LBRY and then closing

### DIFF
--- a/src/main/createWindow.js
+++ b/src/main/createWindow.js
@@ -78,7 +78,14 @@ export default appState => {
   window.on('close', event => {
     if (!appState.isQuitting && !appState.autoUpdateAccepted) {
       event.preventDefault();
-      window.hide();
+      if (window.isFullScreen()) {
+        window.once('leave-full-screen', () => {
+          window.hide();
+        });
+        window.setFullScreen(false);
+      } else {
+        window.hide();
+      }
     }
   });
 


### PR DESCRIPTION
This would close #1200.

What this does is, when closing a window, wait for a full screen window to leave full screen mode first, before actually attempting t close it.

This works on macOS, but the code _has not_ been tested on other platforms.