### PR TITLE
build: bump electron from 1.7.13 to 1.8.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ development and testing purposes.
 * [Git](https://git-scm.com/downloads)
 * [Node.js](https://nodejs.org/en/download/)
 * [Yarn](https://yarnpkg.com/en/docs/install)
+* [C++ Build Tools](https://github.com/felixrieseberg/windows-build-tools) (Only needed on Windows)
 
 ### One-time Setup
 

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "decompress": "^4.2.0",
     "del": "^3.0.0",
     "devtron": "^1.4.0",
-    "electron": "1.7.13",
+    "electron": "^1.8.4",
     "electron-builder": "^20.8.1",
     "electron-devtools-installer": "^2.2.3",
     "electron-webpack": "^1.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -117,9 +117,9 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@types/node@^7.0.18":
-  version "7.0.58"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.58.tgz#ae852120137f40a29731a559e48003bd2d5d19f7"
+"@types/node@^8.0.24":
+  version "8.10.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.1.tgz#aac98b810c50568054486f2bb8c486d824713be8"
 
 "@types/webpack-env@^1.13.5":
   version "1.13.5"
@@ -3098,11 +3098,11 @@ electron-window-state@^4.1.1:
     jsonfile "^2.2.3"
     mkdirp "^0.5.1"
 
-electron@1.7.13:
-  version "1.7.13"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.7.13.tgz#10851baec77d686d95812f34425c17e48ac1413f"
+electron@1.8.4:
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.8.4.tgz#cca8d0e6889f238f55b414ad224f03e03b226a38"
   dependencies:
-    "@types/node" "^7.0.18"
+    "@types/node" "^8.0.24"
     electron-download "^3.0.1"
     extract-zip "^1.0.3"
 


### PR DESCRIPTION
This adds Windows build tools as a prerequisite on Windows.