### PR TITLE
Pre-fill publish URL after clicking "Put something here" link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
    * Add referral FAQ to Invites screen([#1314](https://github.com/lbryio/lbry-app/pull/1314))
    * Show exact wallet balance on mouse hover over ([#1305](https://github.com/lbryio/lbry-app/pull/1305))
    * New dark mode ([#1269](https://github.com/lbryio/lbry-app/pull/1269))
+   * Pre-fill publish URL after clicking "Put something here" link ([#1303](https://github.com/lbryio/lbry-app/pull/1303))
 
 ### Changed
 * Add flair to snackbar ([#1313](https://github.com/lbryio/lbry-app/pull/1313))

--- a/src/renderer/component/fileTile/index.js
+++ b/src/renderer/component/fileTile/index.js
@@ -7,7 +7,7 @@ import {
   makeSelectIsUriResolving,
 } from 'lbry-redux';
 import { doNavigate } from 'redux/actions/navigation';
-import { selectShowNsfw } from 'redux/selectors/settings';
+import { doClearPublish, doUpdatePublishForm } from 'redux/actions/publish';
 import { selectRewardContentClaimIds } from 'redux/selectors/content';
 import FileTile from './view';
 
@@ -20,8 +20,10 @@ const select = (state, props) => ({
 });
 
 const perform = dispatch => ({
+  clearPublish: () => dispatch(doClearPublish()),
   navigate: (path, params) => dispatch(doNavigate(path, params)),
   resolveUri: uri => dispatch(doResolveUri(uri)),
+  updatePublishForm: value => dispatch(doUpdatePublishForm(value)),
 });
 
 export default connect(select, perform)(FileTile);

--- a/src/renderer/component/fileTile/view.jsx
+++ b/src/renderer/component/fileTile/view.jsx
@@ -4,7 +4,6 @@ import * as icons from 'constants/icons';
 import { normalizeURI, isURIClaimable, parseURI } from 'lbry-redux';
 import CardMedia from 'component/cardMedia';
 import TruncatedText from 'component/common/truncated-text';
-import FilePrice from 'component/filePrice';
 import Icon from 'component/common/icon';
 import Button from 'component/button';
 import classnames from 'classnames';
@@ -25,6 +24,8 @@ type Props = {
   metadata: {},
   resolveUri: string => void,
   navigate: (string, ?{}) => void,
+  clearPublish: () => void,
+  updatePublishForm: () => void,
 };
 
 class FileTile extends React.PureComponent<Props> {
@@ -55,6 +56,8 @@ class FileTile extends React.PureComponent<Props> {
       fullWidth,
       showLocal,
       isDownloaded,
+      clearPublish,
+      updatePublishForm,
     } = this.props;
 
     const uri = normalizeURI(this.props.uri);
@@ -69,7 +72,7 @@ class FileTile extends React.PureComponent<Props> {
     let name;
     let channel;
     if (claim) {
-      name = claim.name;
+      ({ name } = claim);
       channel = claim.channel_name;
     }
 
@@ -79,6 +82,9 @@ class FileTile extends React.PureComponent<Props> {
           'file-tile--fullwidth': fullWidth,
         })}
         onClick={onClick}
+        onKeyUp={onClick}
+        role="button"
+        tabIndex="0"
       >
         <CardMedia title={title || name} thumbnail={thumbnail} />
         <div className="file-tile__info">
@@ -101,7 +107,11 @@ class FileTile extends React.PureComponent<Props> {
                     label={__('Put something here!')}
                     onClick={e => {
                       // avoid navigating to /show from clicking on the section
-                      e.preventDefault();
+                      e.stopPropagation();
+                      // strip prefix from the Uri and use that as navigation parameter
+                      const nameFromUri = uri.replace(/lbry:\/\//g, '').replace(/-/g, ' ');
+                      clearPublish(); // to remove any existing publish data
+                      updatePublishForm({ name: nameFromUri }); // to populate the name
                       navigate('/publish');
                     }}
                   />


### PR DESCRIPTION
This addresses #1284.

When "put something here" link is clicked, the URL here is first stripped of the lbry:// prefix, and then given as a navigation parameter. Then, the publish page uses this parameter to pre-fill the URL field in the form. Also, if the parameter exists, adding the actual file to be published will not overwrite the URL with the chosen file name.