### PR TITLE
Refactor file page controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
    * Add flair to snackbar ([#1313](https://github.com/lbryio/lbry-app/pull/1313))
+   * Move file page controls under the content ([#1306](https://github.com/lbryio/lbry-app/pull/1306))
 
 ### Fixed
    * Black screen on macOS after maximizing LBRY and then closing ([#1235](https://github.com/lbryio/lbry-app/pull/1235))

--- a/src/renderer/component/fileActions/view.jsx
+++ b/src/renderer/component/fileActions/view.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import Button from 'component/button';
 import FileDownloadLink from 'component/fileDownloadLink';
 import * as modals from 'constants/modal_types';
-import classnames from 'classnames';
 import * as icons from 'constants/icons';
 
 type FileInfo = {
@@ -15,21 +14,21 @@ type Props = {
   openModal: ({ id: string }, { uri: string }) => void,
   claimIsMine: boolean,
   fileInfo: FileInfo,
-  vertical?: boolean, // should the buttons be stacked vertically?
 };
 
 class FileActions extends React.PureComponent<Props> {
   render() {
-    const { fileInfo, uri, openModal, claimIsMine, vertical } = this.props;
+    const { fileInfo, uri, openModal, claimIsMine } = this.props;
 
     const claimId = fileInfo ? fileInfo.claim_id : '';
     const showDelete = fileInfo && Object.keys(fileInfo).length > 0;
 
     return (
-      <section className={classnames('card__actions', { 'card__actions--vertical': vertical })}>
+      <section className="card__actions file__actions">
         <FileDownloadLink uri={uri} />
         {showDelete && (
           <Button
+            button="alt"
             className="btn--file-actions"
             icon={icons.TRASH}
             description={__('Delete')}
@@ -38,6 +37,7 @@ class FileActions extends React.PureComponent<Props> {
         )}
         {!claimIsMine && (
           <Button
+            button="alt"
             className="btn--file-actions"
             icon={icons.REPORT}
             href={`https://lbry.io/dmca?claim_id=${claimId}`}

--- a/src/renderer/component/fileDownloadLink/view.jsx
+++ b/src/renderer/component/fileDownloadLink/view.jsx
@@ -1,19 +1,11 @@
+/* eslint-disable react/prop-types */
 import React from 'react';
-import Button from 'component/button';
 import classnames from 'classnames';
+import Button from 'component/button';
 import * as icons from 'constants/icons';
 
 class FileDownloadLink extends React.PureComponent {
-  componentWillMount() {
-    this.checkAvailability(this.props.uri);
-  }
-
-  componentWillReceiveProps(nextProps) {
-    this.checkAvailability(nextProps.uri);
-    this.restartDownload(nextProps);
-  }
-
-  restartDownload(props) {
+  static restartDownload(props) {
     const { downloading, fileInfo, uri, restartDownload } = props;
 
     if (
@@ -27,9 +19,18 @@ class FileDownloadLink extends React.PureComponent {
     }
   }
 
+  componentWillMount() {
+    this.checkAvailability(this.props.uri);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.checkAvailability(nextProps.uri);
+    FileDownloadLink.restartDownload(nextProps);
+  }
+
   checkAvailability(uri) {
-    if (!this._uri || uri !== this._uri) {
-      this._uri = uri;
+    if (!this.thisUri || uri !== this.thisUri) {
+      this.thisUri = uri;
       this.props.checkAvailability(uri);
     }
   }
@@ -64,7 +65,6 @@ class FileDownloadLink extends React.PureComponent {
             className={classnames('file-download__overlay', {
               btn__content: !!progress,
             })}
-            style={{ width: `${progress}%` }}
           >
             {label}
           </div>
@@ -78,6 +78,7 @@ class FileDownloadLink extends React.PureComponent {
 
       return (
         <Button
+          button="alt"
           className="btn--file-actions"
           description={__('Download')}
           icon={icons.DOWNLOAD}
@@ -89,6 +90,7 @@ class FileDownloadLink extends React.PureComponent {
     } else if (fileInfo && fileInfo.download_path) {
       return (
         <Button
+          button="alt"
           className="btn--file-actions"
           description={__('Open')}
           icon={icons.OPEN}

--- a/src/renderer/page/file/view.jsx
+++ b/src/renderer/page/file/view.jsx
@@ -49,6 +49,25 @@ type Props = {
 };
 
 class FilePage extends React.Component<Props> {
+  static checkSubscription(props) {
+    if (
+      props.subscriptions
+        .map(subscription => subscription.channelName)
+        .indexOf(props.claim.channel_name) !== -1
+    ) {
+      props.checkSubscription({
+        channelName: props.claim.channel_name,
+        uri: buildURI(
+          {
+            contentName: props.claim.channel_name,
+            claimId: props.claim.value.publisherSignature.certificateId,
+          },
+          false
+        ),
+      });
+    }
+  }
+
   componentDidMount() {
     const { uri, fileInfo, fetchFileInfo, costInfo, fetchCostInfo } = this.props;
 
@@ -60,7 +79,7 @@ class FilePage extends React.Component<Props> {
       fetchCostInfo(uri);
     }
 
-    this.checkSubscription(this.props);
+    FilePage.checkSubscription(this.props);
   }
 
   componentWillReceiveProps(nextProps: Props) {
@@ -106,7 +125,7 @@ class FilePage extends React.Component<Props> {
     } = this.props;
 
     // File info
-    const { title, thumbnail } = metadata;
+    const { thumbnail, title } = metadata;
     const isRewardContent = rewardedContentClaimIds.includes(claim.claim_id);
     const shouldObscureThumbnail = obscureNsfw && metadata.nsfw;
     const { height, channel_name: channelName, value } = claim;
@@ -134,11 +153,6 @@ class FilePage extends React.Component<Props> {
             ) : (
               <Thumbnail shouldObscure={shouldObscureThumbnail} src={thumbnail} />
             )}
-            {!isPlaying && (
-              <div className="card-media__internal-links">
-                <FileActions uri={uri} vertical />
-              </div>
-            )}
             <div className="card__content">
               <div className="card__title-identity--file">
                 <h1 className="card__title card__title--file">{title}</h1>
@@ -147,10 +161,17 @@ class FilePage extends React.Component<Props> {
                   {isRewardContent && <Icon icon={icons.FEATURED} />}
                 </div>
               </div>
-              <span className="card__subtitle card__subtitle--file">
-                {__('Published on')}&nbsp;
-                <DateTime block={height} show={DateTime.SHOW_DATE} />
-              </span>
+              <div className="card__subtitle--file">
+                <span className="card__subtitle">
+                  {__('Published on')}&nbsp;
+                  <DateTime block={height} show={DateTime.SHOW_DATE} />
+                </span>
+                {!isPlaying && (
+                  <div className="card-media__internal-links">
+                    <FileActions uri={uri} />
+                  </div>
+                )}
+              </div>
               {metadata.nsfw && <div>NSFW</div>}
               <div className="card__channel-info">
                 <UriIndicator uri={uri} link />

--- a/src/renderer/scss/component/_button.scss
+++ b/src/renderer/scss/component/_button.scss
@@ -189,9 +189,6 @@ button:disabled {
 }
 
 .btn.btn--file-actions {
-  background-color: var(--color-black);
-  color: var(--color-white);
-  opacity: 0.8;
   border-radius: var(--btn-radius);
   width: var(--btn-height);
   height: var(--btn-height);

--- a/src/renderer/scss/component/_card.scss
+++ b/src/renderer/scss/component/_card.scss
@@ -131,6 +131,13 @@
   }
 }
 
+.card__subtitle--file {
+  align-items: baseline;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
 .card__subtitle--file-info {
   display: flex;
   align-items: center;
@@ -145,15 +152,6 @@
   font-size: 14px;
   font-family: 'metropolis-medium';
   padding-top: $spacing-vertical * 2/3;
-}
-
-// .card-media__internal__links should always be inside a card
-.card {
-  .card-media__internal-links {
-    position: absolute;
-    top: $spacing-vertical * 2/3;
-    right: $spacing-vertical * 2/3;
-  }
 }
 
 .card--small {
@@ -203,6 +201,10 @@
 
   &:not(.card__actions--vertical) .btn:nth-child(n + 2) {
     margin-left: $spacing-vertical / 3;
+  }
+
+  &.file__actions {
+    margin-top: 0px;
   }
 }
 

--- a/src/renderer/scss/component/_file-download.scss
+++ b/src/renderer/scss/component/_file-download.scss
@@ -1,26 +1,19 @@
 .file-download,
 .file-download__overlay {
   padding: 5px;
+  width: 100%;
 }
 
 .file-download {
-  position: relative;
-  background-color: var(--color-black);
-  border-radius: var(--btn-radius);
   color: var(--color-download);
   font-size: 12px;
   opacity: 0.8;
   font-family: 'metropolis-medium';
+  height: 36px;
 }
 
 .file-download__overlay {
   background: var(--color-download);
   color: var(--color-download-overlay);
-  border-radius: var(--btn-radius);
-  position: absolute;
-  white-space: nowrap;
-  overflow: hidden;
-  z-index: 1;
-  top: 0px;
-  left: 0px;
+  width: 100%;
 }


### PR DESCRIPTION
This is a suggested solution for #1272.

The controls were moved below the video horizontally. Also their style was altered to reflect the other buttons under the video.

There's an "eslint-disable react/prop-types" rule in one of the files, mainly because the object structure of some of the props was a bit complex to figure out for this PR.

Screenshots:

<img width="768" alt="screen shot 2018-04-09 at 10 42 51" src="https://user-images.githubusercontent.com/16205520/38486866-f5b1610e-3be6-11e8-8e61-9b327b68b0e1.png">

<img width="754" alt="screen shot 2018-04-09 at 10 43 10" src="https://user-images.githubusercontent.com/16205520/38486878-fb658c1a-3be6-11e8-99cd-202f69c4c250.png">

<img width="748" alt="screen shot 2018-04-09 at 10 43 25" src="https://user-images.githubusercontent.com/16205520/38486888-057a8304-3be7-11e8-9c06-939231956642.png">

<img width="761" alt="screen shot 2018-04-09 at 10 44 21" src="https://user-images.githubusercontent.com/16205520/38486896-0be16f50-3be7-11e8-9f9a-2298d8f50c25.png">
