### PR TITLE
Fix spacing in search suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
    * Fix download percentage indicator overlay ([#1271](https://github.com/lbryio/lbry-app/issues/1271))
    * Fix alternate row shading for transactions on dark theme ([#1355](https://github.com/lbryio/lbry-app/issues/#1355))
    * Fix Description box on Publish (dark theme) ([#1356](https://github.com/lbryio/lbry-app/issues/#1356))
+   * Fix spacing in search suggestions ([#1422])(https://github.com/lbryio/lbry-app/pull/1422))
 
 
 ## [0.21.3] - 2018-04-23

--- a/src/renderer/scss/component/_search.scss
+++ b/src/renderer/scss/component/_search.scss
@@ -51,24 +51,29 @@
   background-color: var(--search-bg-color);
   cursor: pointer;
   display: flex;
-  align-items: center;
-  text-overflow: ellipsis;
+  flex-direction: row;
+  justify-items: flex-start;
   font-family: 'metropolis-medium';
 
   &:not(:first-of-type) {
     border-top: 1px solid var(--search-item-border-color);
   }
+
+  .icon {
+    flex-shrink: 0;
+  }
 }
 
 .wunderbar__suggestion-label {
+  overflow: hidden;
   padding-left: $spacing-vertical;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .wunderbar__suggestion-label--action {
   margin-left: $spacing-vertical * 1/3;
   white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 .wunderbar__active-suggestion {


### PR DESCRIPTION
This fixes #1366.

For some reason, moving the `.icon` style here on the same level as `.wunderbar__suggestion-label` didn't work, only when it's under `.wunderbar__suggestion`.

<img width="498" alt="screen shot 2018-05-02 at 15 16 43" src="https://user-images.githubusercontent.com/16205520/39522891-6cec63d0-4e1c-11e8-9f15-97770f674302.png">