### PR TITLE
Remove price placeholder during thumbnail loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
    * Add flair to snackbar ([#1313](https://github.com/lbryio/lbry-app/pull/1313))
+   * Remove price placeholder during thumbnail loading ([#1431](https://github.com/lbryio/lbry-app/pull/1431))
 
 ### Fixed
    * Black screen on macOS after maximizing LBRY and then closing ([#1235](https://github.com/lbryio/lbry-app/pull/1235))

--- a/src/renderer/component/filePrice/view.jsx
+++ b/src/renderer/component/filePrice/view.jsx
@@ -16,29 +16,17 @@ class FilePrice extends React.PureComponent<Props> {
     showFullPrice: false,
   };
 
-  componentWillMount() {
-    this.fetchCost(this.props);
-  }
-
-  componentWillReceiveProps(nextProps: Props) {
-    this.fetchCost(nextProps);
-  }
-
-  fetchCost = (props: Props) => {
-    const { costInfo, fetchCostInfo, uri, fetching, claim } = props;
+  render() {
+    const { claim, costInfo, fetchCostInfo, fetching, showFullPrice, uri } = this.props;
 
     if (costInfo === undefined && !fetching && claim) {
       fetchCostInfo(uri);
     }
-  };
-
-  render() {
-    const { costInfo, showFullPrice } = this.props;
 
     const isEstimate = costInfo ? !costInfo.includesData : false;
 
     if (!costInfo) {
-      return <span className="credit-amount">PRICE</span>;
+      return null;
     }
 
     return (


### PR DESCRIPTION
This would fix #1427.

Note: the actual fix is just to return null in the `if (!costInfo)` block.

However, committing that was prevented by linter error `PropType is defined but prop is never used` for multiple props, even if those props are being used.

As a workaround and for less code, I think that it's enough to check props and call `fetchCostInfo` only in `render` function. Linter is happy this way. What do you think?