### PR TITLE
Show modal when claiming a reward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
    * Fix price wrapping in price badge ([#1420](https://github.com/lbryio/lbry-app/pull/1420))
    * Fix spacing in search suggestions ([#1422])(https://github.com/lbryio/lbry-app/pull/1422))
    * Fix text/HTML files don't display correctly in-app anymore ([#1379])(https://github.com/lbryio/lbry-app/issues/1379)
+   * Fix notification modals when reward is claimed ([#1436])(https://github.com/lbryio/lbry-app/issues/1436) and ([#1407])(https://github.com/lbryio/lbry-app/issues/1407)
 
 ## [0.21.3] - 2018-04-23
 

--- a/src/renderer/redux/actions/rewards.js
+++ b/src/renderer/redux/actions/rewards.js
@@ -1,6 +1,6 @@
 import * as ACTIONS from 'constants/action_types';
-import { MODALS } from 'lbry-redux';
 import Lbryio from 'lbryio';
+import { doNotify, MODALS } from 'lbry-redux';
 import { selectUnclaimedRewardsByType } from 'redux/selectors/rewards';
 import { selectUserIsRewardApproved } from 'redux/selectors/user';
 import rewards from 'rewards';
@@ -40,10 +40,11 @@ export function doClaimRewardType(rewardType) {
     }
 
     if (!userIsRewardApproved && rewardType !== rewards.TYPE_CONFIRM_EMAIL) {
-      dispatch({
-        type: ACTIONS.OPEN_MODAL,
-        data: { modal: MODALS.REWARD_APPROVAL_REQUIRED },
+      const action = doNotify({
+        id: MODALS.REWARD_APPROVAL_REQUIRED,
+        isError: false,
       });
+      dispatch(action);
 
       return;
     }
@@ -61,10 +62,11 @@ export function doClaimRewardType(rewardType) {
         },
       });
       if (successReward.reward_type === rewards.TYPE_NEW_USER) {
-        dispatch({
-          type: ACTIONS.OPEN_MODAL,
-          data: { modal: MODALS.FIRST_REWARD },
+        const action = doNotify({
+          id: MODALS.FIRST_REWARD,
+          isError: false,
         });
+        dispatch(action);
       }
     };
 


### PR DESCRIPTION
This fixes PART of the issues reported in #1436  
As  @tzarebczan reported,  this error `Uncaught (in promise) Error: Actions may not have an undefined "type" property. Have you misspelled a constant?`, the constant ACTIONS.OPEN_MODALS is not defined anymore and it throws that error as the type for an action when dispatching it is undefined:
```
dispatch({
          type: ACTIONS.OPEN_MODAL,
          data: { modal: MODALS.FIRST_REWARD },
        });
```
Seems like the code to open modals have been refactored and changed to notifications, as far as I understand. 
![screenshot from 2018-05-07 22-30-13](https://user-images.githubusercontent.com/3293616/39732892-46f27506-5246-11e8-88d2-4a309fd40484.png)
