### PR TITLE
Fix grayed out rewards cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
    * Fix don't allow dark mode with automatic night mode enabled ([#1005](https://github.com/lbryio/lbry-app/issues/1005))
    * Fix description box on Publish (dark theme) ([#1356](https://github.com/lbryio/lbry-app/issues/#1356))
    * Fix price wrapping in price badge ([#1420](https://github.com/lbryio/lbry-app/pull/1420))
-   * Fix spacing in search suggestions ([#1422](https://github.com/lbryio/lbry-app/pull/1422))
-   * Fix text/HTML files don't display correctly in-app anymore ([#1379](https://github.com/lbryio/lbry-app/issues/1379))
-   * Fix notification modals when reward is claimed ([#1436](https://github.com/lbryio/lbry-app/issues/1436)) and ([#1407](https://github.com/lbryio/lbry-app/issues/1407))
+   * Fix spacing in search suggestions ([#1422])(https://github.com/lbryio/lbry-app/pull/1422))
+   * Fix text/HTML files don't display correctly in-app anymore ([#1379])(https://github.com/lbryio/lbry-app/issues/1379)
+   * Fix notification modals when reward is claimed ([#1436])(https://github.com/lbryio/lbry-app/issues/1436) and ([#1407])(https://github.com/lbryio/lbry-app/issues/1407)
+   * Fix disabled cards(grayed out) ([#1466])(https://github.com/lbryio/lbry-app/issues/1466)
    * Fix markdown render ([#1179](https://github.com/lbryio/lbry-app/issues/1179))
+
 
 ## [0.21.3] - 2018-04-23
 

--- a/src/renderer/page/rewards/view.jsx
+++ b/src/renderer/page/rewards/view.jsx
@@ -14,6 +14,9 @@ type Props = {
   rewards: Array<{ reward_type: boolean }>,
   user: ?{
     is_identity_verified: boolean,
+    is_reward_approved: boolean,
+    primary_email: string,
+    has_verified_email: boolean,
   },
   daemonSettings: {
     share_usage_data: boolean,
@@ -131,8 +134,7 @@ class RewardsPage extends React.PureComponent<Props> {
     }
 
     const isNotEligible =
-      !user || !user.primary_email || !user.has_verified_email || !user.is_identity_verified;
-
+      !user || !user.primary_email || !user.has_verified_email || !user.is_reward_approved;
     return (
       <div
         className={classnames('card__list--rewards', {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3100,7 +3100,7 @@ electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.30:
   version "1.3.45"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.45.tgz#458ac1b1c5c760ce8811a16d2bfbd97ec30bafb8"
 
-electron-updater@^2.21.4:
+electron-updater@^2.21.10:
   version "2.21.10"
   resolved "https://registry.yarnpkg.com/electron-updater/-/electron-updater-2.21.10.tgz#aa66757ebf966f4247f247a8433af45cfe8e93b0"
   dependencies:


### PR DESCRIPTION
Fix #1466 as the check for eligibility was using `user.is_identity_verified` instead of `user.is_reward_approved` which is the proper way of checking  if the user can claim rewards or not.