### PR TITLE
bump render-media

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "redux-thunk": "^2.2.0",
     "remark": "^9.0.0",
     "remark-react": "^4.0.3",
-    "render-media": "^2.12.0",
+    "render-media": "^3.1.0",
     "reselect": "^3.0.0",
     "semver": "^5.3.0",
     "shapeshift.io": "^1.3.1",


### PR DESCRIPTION
See changes here: https://github.com/feross/render-media/commits/master

Will fix https://github.com/lbryio/lbry-app/issues/931 as it won't prompt to save anymore, but the PDF does not render in-app per the comments.

Tested videos in app briefly, doesn't look like anything breaks. 