### PR TITLE
Add display type to notifications to allow snackbar to be shown.

### DIFF
--- a/src/renderer/rewards.js
+++ b/src/renderer/rewards.js
@@ -56,6 +56,7 @@ rewards.claimReward = type => {
         linkText: __('Show All'),
         linkTarget: '/rewards',
         isError: false,
+        displayType: ['snackbar'],
       });
       window.app.store.dispatch(action);
 


### PR DESCRIPTION
Closes issue #1488, I've searched on the entire codebase to check if there is any place where `doNotify` was being called without  `displayType` property(thanks @tzarebczan, your comment helped a lot! ).
@seanyesmunt  I wonder if we should add a default `displayType`(ex: `["snackbars"]`) in case someone forgets to add it while calling the function `doNotify`, anyway currently I've not added any default and just fixed the issue reported on #1488 

This issue on #1488 :
```
Another user had reported something similar on the show page - 
he was unable to click the delete button (could click, but not action), until a restart.
```
Was also related to the notifications being queued but not dispatched because the `displayType` was not set, I could reproduce and tested the fix.



