### PR TITLE
Toggle video fullscreen on doubleclick.

### DIFF
--- a/src/renderer/component/video/internal/player.jsx
+++ b/src/renderer/component/video/internal/player.jsx
@@ -19,6 +19,7 @@ class VideoPlayer extends React.PureComponent {
     };
 
     this.togglePlayListener = this.togglePlay.bind(this);
+    this.toggleFullScreenVideo = this.toggleFullScreen.bind(this);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -77,6 +78,7 @@ class VideoPlayer extends React.PureComponent {
         changeVolume(mediaElement.volume);
       });
       mediaElement.volume = volume;
+      mediaElement.addEventListener('dblclick', this.toggleFullScreenVideo);
     }
   }
 
@@ -110,6 +112,17 @@ class VideoPlayer extends React.PureComponent {
       mediaElement.removeEventListener('click', this.togglePlayListener);
     }
     this.props.doPause();
+  }
+
+  toggleFullScreen(event) {
+    const mediaElement = this.media.children[0];
+    if (mediaElement) {
+      if (document.webkitIsFullScreen) {
+        document.webkitExitFullscreen();
+      } else {
+        mediaElement.webkitRequestFullScreen();
+      }
+    }
   }
 
   togglePlay(event) {


### PR DESCRIPTION
This PR closes issue #1463 , which adds a callback on double click event and toggles the full screen on videos. I've only tested this on videos(I've only added the callback event when the element is a video type)