### PR TITLE
fix: use short form uri when preparingEdit so users know they are editing

### DIFF
--- a/src/renderer/page/file/view.jsx
+++ b/src/renderer/page/file/view.jsx
@@ -129,6 +129,14 @@ class FilePage extends React.Component<Props> {
       subscriptionUri = buildURI({ channelName, claimId: channelClaimId }, false);
     }
 
+    // We want to use the short form uri for editing
+    // This is what the user is used to seeing, they don't care about the claim id
+    // We will select the claim id before they publish
+    let editUri;
+    if (claimIsMine) {
+      editUri = buildURI({ channelName, contentName: claim.name });
+    }
+
     const isPlaying = playingUri === uri && !isPaused;
     return (
       <Page extraPadding>
@@ -170,7 +178,7 @@ class FilePage extends React.Component<Props> {
                       icon={icons.EDIT}
                       label={__('Edit')}
                       onClick={() => {
-                        prepareEdit(claim, uri);
+                        prepareEdit(claim, editUri);
                         navigate('/publish');
                       }}
                     />

--- a/src/renderer/redux/reducers/navigation.js
+++ b/src/renderer/redux/reducers/navigation.js
@@ -3,7 +3,7 @@ import * as ACTIONS from 'constants/action_types';
 const getCurrentPath = () => {
   const { hash } = document.location;
   if (hash !== '') return hash.replace(/^#/, '');
-  return '/discover';
+  return '/publish';
 };
 
 const reducers = {};


### PR DESCRIPTION
Fixes https://github.com/lbryio/lbry-app/issues/1499
We store the short form of the uri being edited. That was causing an issue with properly prefilling claim edits because we were passing in the long form with a claim id. In the place that we were checking if the current uri is equal to the uri being edited, they were different so it wasn't working.

```
// check to see if you are editing
// editingUri === uri

// before
lbry://@channelName#xxx.../claim-name === lbry://@channelName/claim-name

```