### PR TITLE
Allow https to follow redirection when requesting latest release data

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -176,11 +176,11 @@ ipcMain.on('version-info-requested', () => {
     },
   };
   let result = '';
-
-  const req = https.get(Object.assign(opts, url.parse(latestReleaseAPIURL)), res => {
+  const onSuccess = res => {
     res.on('data', data => {
       result += data;
     });
+
     res.on('end', () => {
       const tagName = JSON.parse(result).tag_name;
       const [, remoteVersion] = tagName.match(/^v([\d.]+(?:-?rc\d+)?)$/);
@@ -199,14 +199,27 @@ ipcMain.on('version-info-requested', () => {
         }
       }
     });
-  });
+  };
 
-  req.on('error', err => {
-    console.log('Failed to get current version from GitHub. Error:', err);
-    if (rendererWindow) {
-      rendererWindow.webContents.send('version-info-received', null);
-    }
-  });
+  const requestLatestRelease = (apiUrl, alreadyRedirected = false) => {
+    const req = https.get(Object.assign(opts, url.parse(apiUrl)), res => {
+      if (res.statusCode === 301 || res.statusCode === 302) {
+        requestLatestRelease(res.headers.location, true);
+      } else {
+        onSuccess(res);
+      }
+    });
+
+    if (alreadyRedirected) return;
+    req.on('error', err => {
+      console.log('Failed to get current version from GitHub. Error:', err);
+      if (rendererWindow) {
+        rendererWindow.webContents.send('version-info-received', null);
+      }
+    });
+  };
+
+  requestLatestRelease(latestReleaseAPIURL);
 });
 
 ipcMain.on('get-auth-token', event => {


### PR DESCRIPTION
Closes #1505  as it allows https to follow redirections, it checks for status 301 and 302.

I've looked through [https docs](https://nodejs.org/api/https.html) and [github https](https://github.com/nodejs/node/blob/master/lib/https.js) to see if there was an easier way or option to allow redirections, but I couldn't find anything.