### PR TITLE
reject claim_list_by_channel when no uri is passed

### DIFF
--- a/src/renderer/redux/actions/content.js
+++ b/src/renderer/redux/actions/content.js
@@ -342,6 +342,10 @@ export function doPurchaseUri(uri, specificCostInfo) {
 
 export function doFetchClaimsByChannel(uri, page) {
   return (dispatch, getState) => {
+    if (!uri) {
+      return;
+    }
+
     dispatch({
       type: ACTIONS.FETCH_CHANNEL_CLAIMS_STARTED,
       data: { uri, page },
@@ -395,6 +399,10 @@ export function doFetchClaimsByChannel(uri, page) {
 
 export function doFetchClaimCountByChannel(uri) {
   return dispatch => {
+    if (!uri) {
+      return;
+    }
+
     dispatch({
       type: ACTIONS.FETCH_CHANNEL_CLAIM_COUNT_STARTED,
       data: { uri },

--- a/src/renderer/redux/actions/subscriptions.js
+++ b/src/renderer/redux/actions/subscriptions.js
@@ -127,6 +127,10 @@ export const setSubscriptionNotification = (
 export const doCheckSubscription = (subscription: Subscription, notify?: boolean) => (
   dispatch: Dispatch
 ) => {
+  if (!subscription) {
+    return;
+  }
+
   dispatch({
     type: ACTIONS.CHECK_SUBSCRIPTION_STARTED,
     data: subscription,


### PR DESCRIPTION
@tzarebczan was seeing `claim_list_by_channel` calls on the network with no uri param. This PR prevents that behavior.