### PR TITLE
Add copy text on contex menu.

### DIFF
--- a/src/renderer/component/app/view.jsx
+++ b/src/renderer/component/app/view.jsx
@@ -7,6 +7,7 @@ import ReactModal from 'react-modal';
 import throttle from 'util/throttle';
 import SideBar from 'component/sideBar';
 import Header from 'component/header';
+import { openContextMenu } from '../../util/contextMenu';
 
 type Props = {
   alertError: (string | {}) => void,
@@ -79,7 +80,7 @@ class App extends React.PureComponent<Props> {
 
   render() {
     return (
-      <div id="window">
+      <div id="window" onContextMenu={e => openContextMenu(e)}>
         <Theme />
         <main className="page">
           <SideBar />

--- a/src/renderer/component/fileCard/view.jsx
+++ b/src/renderer/component/fileCard/view.jsx
@@ -62,6 +62,8 @@ class FileCard extends React.PureComponent<Props> {
     const shouldObscureNsfw = obscureNsfw && metadata && metadata.nsfw;
     const isRewardContent = claim && rewardedContentClaimIds.includes(claim.claim_id);
     const handleContextMenu = event => {
+      event.preventDefault();
+      event.stopPropagation();
       openCopyLinkMenu(convertToShareLink(uri), event);
     };
 

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -17,7 +17,6 @@ import store from 'store';
 import app from './app';
 import analytics from './analytics';
 import doLogWarningConsoleMessage from './logWarningConsoleMessage';
-import { initContextMenu } from './util/contextMenu';
 
 const { autoUpdater } = remote.require('electron-updater');
 const APPPAGEURL = 'lbry://?';
@@ -113,8 +112,6 @@ document.addEventListener('click', event => {
   }
 });
 
-document.addEventListener('contextmenu', initContextMenu);
-
 const init = () => {
   autoUpdater.on('update-downloaded', () => {
     app.store.dispatch(doAutoUpdate());
@@ -149,7 +146,7 @@ const init = () => {
     ReactDOM.render(
       <Provider store={store}>
         <div>
-          <App onContextMenu={e => openContextMenu(e)} />
+          <App />
           <SnackBar />
         </div>
       </Provider>,

--- a/src/renderer/util/contextMenu.js
+++ b/src/renderer/util/contextMenu.js
@@ -21,26 +21,41 @@ function injectDevelopmentTemplate(event, templates) {
   return templates;
 }
 
-export function openContextMenu(event, templates = [], addDefaultTemplates = true) {
-  if (addDefaultTemplates) {
-    const { value } = event.target;
-    const inputTemplates = [
-      { label: 'Cut', accelerator: 'CmdOrCtrl+X', role: 'cut' },
-      { label: 'Copy', accelerator: 'CmdOrCtrl+C', role: 'copy' },
-      {
-        label: 'Paste',
-        accelerator: 'CmdOrCtrl+V',
-        role: 'paste',
-        enabled: clipboard.readText().length > 0,
-      },
-      {
-        label: 'Select All',
-        accelerator: 'CmdOrCtrl+A',
-        role: 'selectall',
-        enabled: !!value,
-      },
-    ];
-    templates.push(...inputTemplates);
+export function openContextMenu(event, templates = []) {
+  const isSomethingSelected = window.getSelection().toString().length > 0;
+  const { type } = event.target;
+  const isInput = event.target.matches('input') && (type === 'text' || type === 'number');
+  const { value } = event.target;
+
+  templates.push({
+    label: 'Copy',
+    accelerator: 'CmdOrCtrl+C',
+    role: 'copy',
+    enabled: isSomethingSelected,
+  });
+
+  // If context menu is opened on Input and there is text on the input and something is selected.
+  const { selectionStart, selectionEnd } = event.target;
+  if (!!value && isInput && selectionStart !== selectionEnd) {
+    templates.push({ label: 'Cut', accelerator: 'CmdOrCtrl+X', role: 'cut' });
+  }
+
+  // If context menu is opened on Input and text is present on clipboard
+  if (clipboard.readText().length > 0 && isInput) {
+    templates.push({
+      label: 'Paste',
+      accelerator: 'CmdOrCtrl+V',
+      role: 'paste',
+    });
+  }
+
+  // If context menu is opened on Input
+  if (isInput && value) {
+    templates.push({
+      label: 'Select All',
+      accelerator: 'CmdOrCtrl+A',
+      role: 'selectall',
+    });
   }
 
   injectDevelopmentTemplate(event, templates);
@@ -56,13 +71,4 @@ export function openCopyLinkMenu(text, event) {
     },
   ];
   openContextMenu(event, templates, false);
-}
-
-export function initContextMenu(event) {
-  const { type } = event.target;
-  if (event.target.matches('input') && (type === 'text' || type === 'number')) {
-    openContextMenu(event);
-  } else {
-    event.preventDefault();
-  }
 }


### PR DESCRIPTION
Closes #1538 , So when [PR](https://github.com/lbryio/lbry-app/pull/1486) got merged It introduced a bug which I didn't test (#1538) , this PR add the context menu event to be listened on the `app` component inside the react rather than doing `document.addEventListener`, the function `onContextMenu` can call `event.preventDefault` && `event.stopPropagation` on child elements and that will cancel the call to open the menu handled by `app` component(parent).

![screenshot from 2018-06-03 21-18-58](https://user-images.githubusercontent.com/3293616/40892950-2c629a20-6774-11e8-8fa6-b54a9ae45b5b.png)

Right click on video to copy a link without text being selected(copy is disabled)
![screenshot from 2018-06-03 21-24-18](https://user-images.githubusercontent.com/3293616/40892976-8a61eb08-6774-11e8-869e-56e6a1ca95ba.png)

Right click on video to copy a link with text selected:
![screenshot from 2018-06-03 21-25-30](https://user-images.githubusercontent.com/3293616/40892986-a8c1b984-6774-11e8-8c39-b3efe0e28d40.png)

