### PR TITLE
fix empty uri calls

### DIFF
--- a/src/renderer/component/categoryList/view.jsx
+++ b/src/renderer/component/categoryList/view.jsx
@@ -42,7 +42,7 @@ class CategoryList extends React.PureComponent<Props, State> {
 
   componentDidMount() {
     const { fetching, categoryLink, fetchChannel } = this.props;
-    if (!fetching) {
+    if (!fetching && categoryLink) {
       fetchChannel(categoryLink);
     }
 


### PR DESCRIPTION
`categoryList`'s `componentDidMount` was calling `doFetchClaimsByChannel` without a channel `uri` (categoryLink) which calls `claim_list_by_channel` with no channel