### PR TITLE
fix 1549

### DIFF
--- a/src/main/createWindow.js
+++ b/src/main/createWindow.js
@@ -64,8 +64,12 @@ export default appState => {
     //     path, so we just strip it off.
     //   - In a URI with a claim ID, like lbry://channel#claimid, Windows interprets the hash mark as
     //     an anchor and converts it to lbry://channel/#claimid. We remove the slash here as well.
+    //   - ? also interpreted as an anchor, remove slash also.
     if (process.platform === 'win32') {
-      deepLinkingURI = deepLinkingURI.replace(/\/$/, '').replace('/#', '#');
+      deepLinkingURI = deepLinkingURI
+        .replace(/\/$/, '')
+        .replace('/#', '#')
+        .replace('/?', '?');
     }
   } else {
     deepLinkingURI = appState.macDeepLinkingURI;

--- a/src/renderer/page/rewards/view.jsx
+++ b/src/renderer/page/rewards/view.jsx
@@ -49,7 +49,7 @@ class RewardsPage extends React.PureComponent<Props> {
   renderPageHeader() {
     const { doAuth, navigate, user, daemonSettings } = this.props;
 
-    if (user && !user.is_reward_approved && daemonSettings.share_usage_data) {
+    if (user && !user.is_reward_approved && daemonSettings && daemonSettings.share_usage_data) {
       if (!user.primary_email || !user.has_verified_email || !user.is_identity_verified) {
         return (
           <section className="card card--section">
@@ -98,7 +98,7 @@ class RewardsPage extends React.PureComponent<Props> {
   renderUnclaimedRewards() {
     const { fetching, rewards, user, daemonSettings, navigate } = this.props;
 
-    if (!daemonSettings.share_usage_data) {
+    if (daemonSettings && !daemonSettings.share_usage_data) {
       return (
         <div className="card card--section">
           <div className="card__title">{__('Disabled')}</div>


### PR DESCRIPTION
This fixes page URLs on cold start for Windows and Mac. On windows, createWindow.js is called on coldstart instead of index.js where the same replacement happens. For Mac/Windows, need to make sure daemonSettings is available before reading the share usage property. 