### PR TITLE
Fix issue 1494 - uri and outpoint to API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
    * Fix markdown render ([#1179](https://github.com/lbryio/lbry-app/issues/1179))
    * Fix new lines not showing correctly after markdown changes ([#1504](https://github.com/lbryio/lbry-app/issues/1504))
    * Fix claim ID being null when reporting a claim that was not previously download ([issue#1512](https://github.com/lbryio/lbry-app/issues/1512)) ([PR#1530](https://github.com/lbryio/lbry-app/pull/1530))
+   * Fix URI and outpoint not being passed properly to API ([#1494](https://github.com/lbryio/lbry-app/issues/1494))
 
 
 ## [0.21.3] - 2018-04-23

--- a/src/renderer/redux/actions/content.js
+++ b/src/renderer/redux/actions/content.js
@@ -225,7 +225,11 @@ export function doDownloadFile(uri, streamInfo) {
   return dispatch => {
     dispatch(doStartDownload(uri, streamInfo.outpoint));
 
-    analytics.apiLogView(uri, streamInfo.output, streamInfo.claim_id);
+    analytics.apiLogView(
+      `${streamInfo.claim_name}#${streamInfo.claim_id}`,
+      streamInfo.outpoint,
+      streamInfo.claim_id
+    );
 
     dispatch(doClaimEligiblePurchaseRewards());
   };


### PR DESCRIPTION
This will send the same unique URI for all claims, regardless of what URI the user navigated to. Also fix sending of outpoint (was passed as output, which was blank, previously)