### PR TITLE
fix reward error notification

### DIFF
--- a/src/renderer/redux/actions/rewards.js
+++ b/src/renderer/redux/actions/rewards.js
@@ -27,7 +27,7 @@ export function doRewardList() {
   };
 }
 
-export function doClaimRewardType(rewardType) {
+export function doClaimRewardType(rewardType, options) {
   return (dispatch, getState) => {
     const state = getState();
     const unclaimedRewards = selectUnclaimedRewards(state);
@@ -73,7 +73,10 @@ export function doClaimRewardType(rewardType) {
     const failure = error => {
       dispatch({
         type: ACTIONS.CLAIM_REWARD_FAILURE,
-        data: { reward, error },
+        data: {
+          reward,
+          error: !options || !options.failSilently ? error : undefined,
+        },
       });
     };
 
@@ -95,7 +98,7 @@ export function doClaimEligiblePurchaseRewards() {
       dispatch(doClaimRewardType(rewards.TYPE_FIRST_STREAM));
     } else {
       [rewards.TYPE_MANY_DOWNLOADS, rewards.TYPE_FEATURED_DOWNLOAD].forEach(type => {
-        dispatch(doClaimRewardType(type));
+        dispatch(doClaimRewardType(type, { failSilently: true }));
       });
     }
   };


### PR DESCRIPTION
Fixes #1555 @tzarebczan 

This adds an `option` parameter to `doClaimRewardType` which it uses to fail silently.

`doClaimEligiblePurchaseRewards` (called by each `doDownloadFile`) uses this option when attempting to claim `rewards.TYPE_MANY_DOWNLOADS` and `rewards.TYPE_FEATURED_DOWNLOAD`

The error modal for rewards is in the `<RewardLink>` component and displayed when `errorMessage` is defined. It was getting set in redux and sitting there until a `<RewardLink>` is rendered when a user visits the rewards page. `error` is sent `undefined` in this PR because not calling the error reducer results in the two rewards pending on the rewards page.