### PR TITLE
always update costInfo on FilePage componentDidMount

### DIFF
--- a/src/renderer/page/file/view.jsx
+++ b/src/renderer/page/file/view.jsx
@@ -60,9 +60,7 @@ class FilePage extends React.Component<Props> {
       fetchFileInfo(uri);
     }
 
-    if (costInfo === undefined) {
-      fetchCostInfo(uri);
-    }
+    fetchCostInfo(uri);
 
     this.checkSubscription(this.props);
   }

--- a/src/renderer/page/file/view.jsx
+++ b/src/renderer/page/file/view.jsx
@@ -54,12 +54,13 @@ class FilePage extends React.Component<Props> {
   }
 
   componentDidMount() {
-    const { uri, fileInfo, fetchFileInfo, costInfo, fetchCostInfo } = this.props;
+    const { uri, fileInfo, fetchFileInfo, fetchCostInfo } = this.props;
 
     if (fileInfo === undefined) {
       fetchFileInfo(uri);
     }
 
+    // See https://github.com/lbryio/lbry-app/pull/1563 for discussion
     fetchCostInfo(uri);
 
     this.checkSubscription(this.props);


### PR DESCRIPTION
#797 @tzarebczan 

Call `fetchCostInfo` whenever `<FilePage>` mounts. All `fetchCostInfo` does is update `costInfo` based on `fileInfo`; there is no api call. So running it whenever a user visits a claim is not a problem where fetching `fileInfo` from the daemon could slow things down significantly.

I don't like this solution but refactoring everything about `costInfo` would be more involved and [there may be reasons for this design which are not apparent to me](https://en.wikipedia.org/wiki/Wikipedia:Chesterton's_fence).