### PR TITLE
Adding ability to view logs and open log directory

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -20,5 +20,6 @@ module.name_mapper='^lbry\(.*\)$' -> '<PROJECT_ROOT>/src/renderer/lbry\1'
 module.name_mapper='^rewards\(.*\)$' -> '<PROJECT_ROOT>/src/renderer/rewards\1'
 module.name_mapper='^modal\(.*\)$' -> '<PROJECT_ROOT>/src/renderer/modal\1'
 module.name_mapper='^app\(.*\)$' -> '<PROJECT_ROOT>/src/renderer/app\1'
+module.name_mapper='^native\(.*\)$' -> '<PROJECT_ROOT>/src/renderer/native\1'
 
 [strict]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
    * Move rewards logic to interal api ([#1509](https://github.com/lbryio/lbry-app/pull/1509))
 
 ### Fixed
+   * Fixing content address extending outside of visible area. ([#741](https://github.com/lbryio/lbry-app/issues/741))
    * Fix content-type not shown correctly in file description ([#863](https://github.com/lbryio/lbry-app/pull/863))
    * Fix [Flow](https://flow.org/) ([#1197](https://github.com/lbryio/lbry-app/pull/1197))
    * Fix black screen on macOS after maximizing LBRY and then closing ([#1235](https://github.com/lbryio/lbry-app/pull/1235))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 
+   * Add ability to open log file and log directory in the help page ([#1556](https://github.com/lbryio/lbry-app/issues/1556))
    * Add ability to resend verification email ([#1492](https://github.com/lbryio/lbry-app/issues/1492))
    * Add Narrative about Feature Request on Help Page and Report Page ([#1551](https://github.com/lbryio/lbry-app/pull/1551))
    * Add keyboard shortcut to quit the app on Windows ([#1202](https://github.com/lbryio/lbry-app/pull/1202))

--- a/src/renderer/page/help/index.js
+++ b/src/renderer/page/help/index.js
@@ -1,12 +1,14 @@
 import { connect } from 'react-redux';
 import { doAuthNavigate } from 'redux/actions/navigation';
 import { doFetchAccessToken } from 'redux/actions/user';
+import { selectDaemonSettings } from 'redux/selectors/settings';
 import { selectAccessToken, selectUser } from 'redux/selectors/user';
 import HelpPage from './view';
 
 const select = state => ({
   user: selectUser(state),
   accessToken: selectAccessToken(state),
+  deamonSettings: selectDaemonSettings(state),
 });
 
 const perform = dispatch => ({
@@ -14,4 +16,7 @@ const perform = dispatch => ({
   fetchAccessToken: () => dispatch(doFetchAccessToken()),
 });
 
-export default connect(select, perform)(HelpPage);
+export default connect(
+  select,
+  perform
+)(HelpPage);

--- a/src/renderer/page/help/view.jsx
+++ b/src/renderer/page/help/view.jsx
@@ -10,7 +10,7 @@ import Page from 'component/page';
 import * as icons from 'constants/icons';
 
 type DeamonSettings = {
-  data_dir: string,
+  data_dir: string | any,
 };
 
 type Props = {
@@ -21,12 +21,20 @@ type Props = {
   user: any,
 };
 
+type VersionInfo = {
+  os_system: string,
+  os_release: string,
+  platform: string,
+  lbrynet_version: string,
+  lbryum_version: string,
+};
+
 type State = {
-  versionInfo: any,
+  versionInfo: VersionInfo | any,
   lbryId: any,
-  uiVersion: any,
-  upgradeAvailable: any,
-  accessTokenHidden: any,
+  uiVersion: ?string,
+  upgradeAvailable: ?boolean,
+  accessTokenHidden: ?boolean,
 };
 
 class HelpPage extends React.PureComponent<Props, State> {

--- a/src/renderer/page/help/view.jsx
+++ b/src/renderer/page/help/view.jsx
@@ -1,12 +1,18 @@
 // @TODO: Customize advice based on OS
 import React from 'react';
+import { shell } from 'electron';
 import { Lbry } from 'lbry-redux';
 import Native from 'native';
 import Button from 'component/button';
 import BusyIndicator from 'component/common/busy-indicator';
-import Icon from 'component/common/icon';
 import Page from 'component/page';
 import * as icons from 'constants/icons';
+
+type Props = {
+  deamonSettings: {
+    data_dir: ?string,
+  },
+};
 
 class HelpPage extends React.PureComponent {
   constructor(props) {
@@ -56,7 +62,8 @@ class HelpPage extends React.PureComponent {
     let platform;
     let newVerLink;
 
-    const { accessToken, doAuth, user } = this.props;
+    const { accessToken, doAuth, user, deamonSettings } = this.props;
+    const { data_dir: dataDirectory } = deamonSettings;
 
     if (this.state.versionInfo) {
       ver = this.state.versionInfo;
@@ -109,11 +116,33 @@ class HelpPage extends React.PureComponent {
         </section>
 
         <section className="card card--section">
+          <div className="card__title">{__('View your Log')}</div>
+          <p className="card__subtitle">
+            {__(
+              'Do you find something wrong? Have a look in your log, or send your log to support for some help.'
+            )}
+          </p>
+          <div className="card__actions">
+            <Button
+              button="primary"
+              label={__('Open Log')}
+              icon={icons.REPORT}
+              onClick={() => shell.openItem(`${dataDirectory}/lbrynet.log`)}
+            />
+            <Button
+              button="primary"
+              label={__('Open Log Folder')}
+              icon={icons.REPORT}
+              onClick={() => shell.showItemInFolder(dataDirectory)}
+            />
+          </div>
+        </section>
+
+        <section className="card card--section">
           <div className="card__title">{__('Report a Bug or Suggest a New Feature')}</div>
           <p className="card__subtitle">
             {__('Did you find something wrong? Think LBRY could add something useful and cool?')}
           </p>
-
           <div className="card__actions">
             <Button
               navigate="/report"

--- a/src/renderer/page/help/view.jsx
+++ b/src/renderer/page/help/view.jsx
@@ -1,21 +1,36 @@
 // @TODO: Customize advice based on OS
-import React from 'react';
+// @flow
+import * as React from 'react';
 import { shell } from 'electron';
 import { Lbry } from 'lbry-redux';
-import Native from 'native';
+import * as Native from 'native';
 import Button from 'component/button';
 import BusyIndicator from 'component/common/busy-indicator';
 import Page from 'component/page';
 import * as icons from 'constants/icons';
 
-type Props = {
-  deamonSettings: {
-    data_dir: ?string,
-  },
+type DeamonSettings = {
+  data_dir: string,
 };
 
-class HelpPage extends React.PureComponent {
-  constructor(props) {
+type Props = {
+  deamonSettings: DeamonSettings,
+  accessToken: string,
+  fetchAccessToken: () => void,
+  doAuth: () => void,
+  user: any,
+};
+
+type State = {
+  versionInfo: any,
+  lbryId: any,
+  uiVersion: any,
+  upgradeAvailable: any,
+  accessTokenHidden: any,
+};
+
+class HelpPage extends React.PureComponent<Props, State> {
+  constructor(props: Props) {
     super(props);
 
     this.state = {
@@ -26,11 +41,12 @@ class HelpPage extends React.PureComponent {
       accessTokenHidden: true,
     };
 
-    this.showAccessToken = this.showAccessToken.bind(this);
+    (this: any).showAccessToken = this.showAccessToken.bind(this);
+    (this: any).openLogFile = this.openLogFile.bind(this);
   }
 
   componentDidMount() {
-    Native.getAppVersionInfo().then(({ remoteVersion, localVersion, upgradeAvailable }) => {
+    Native.getAppVersionInfo().then(({ localVersion, upgradeAvailable }) => {
       this.setState({
         uiVersion: localVersion,
         upgradeAvailable,
@@ -54,6 +70,16 @@ class HelpPage extends React.PureComponent {
     this.setState({
       accessTokenHidden: false,
     });
+  }
+
+  openLogFile(userHomeDirectory: string) {
+    const logFileName = 'lbrynet.log';
+    const os = this.state.versionInfo.os_system;
+    if (os === 'Darwin' || os === 'Linux') {
+      shell.openItem(`${userHomeDirectory}/${logFileName}`);
+    } else {
+      shell.openItem(`${userHomeDirectory}\\${logFileName}`);
+    }
   }
 
   render() {
@@ -127,7 +153,7 @@ class HelpPage extends React.PureComponent {
               button="primary"
               label={__('Open Log')}
               icon={icons.REPORT}
-              onClick={() => shell.openItem(`${dataDirectory}/lbrynet.log`)}
+              onClick={() => this.openLogFile(dataDirectory)}
             />
             <Button
               button="primary"

--- a/src/renderer/page/help/view.jsx
+++ b/src/renderer/page/help/view.jsx
@@ -31,7 +31,7 @@ type VersionInfo = {
 
 type State = {
   versionInfo: VersionInfo | any,
-  lbryId: any,
+  lbryId: String | any,
   uiVersion: ?string,
   upgradeAvailable: ?boolean,
   accessTokenHidden: ?boolean,

--- a/src/renderer/page/help/view.jsx
+++ b/src/renderer/page/help/view.jsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { shell } from 'electron';
 import { Lbry } from 'lbry-redux';
-import * as Native from 'native';
+import Native from 'native';
 import Button from 'component/button';
 import BusyIndicator from 'component/common/busy-indicator';
 import Page from 'component/page';

--- a/src/renderer/scss/component/_card.scss
+++ b/src/renderer/scss/component/_card.scss
@@ -8,6 +8,10 @@
   flex-direction: column;
 }
 
+.card > h1 {
+  word-wrap: break-word;
+}
+
 .card--section {
   background-color: var(--card-bg);
   padding: $spacing-vertical;


### PR DESCRIPTION
#1556 - Adding ability to open logs and view log directory on the help page.
#741 -  Fixing content address extending outside of the visible area in the card. (I am including this fix as a part of this PR since it is a small relatively small fix - 3 lines)

### Changes
* Made changes to the code to include a new section to giving users the option to open the log file or the directory that contains the log file. 
* Added some type declarations since eslint and flow checkers were failing on the file that I edited. 
* Added a word wrap while to card's ```h1``` element so that long URLs do not extend outside the visible area.

### Preview 
#1556 
![screen shot 2018-06-09 at 6 30 04 pm](https://user-images.githubusercontent.com/4067311/41196955-308afbbc-6c13-11e8-9f14-6d754e846eb0.png)

#741 
![screen shot 2018-06-10 at 5 15 46 pm](https://user-images.githubusercontent.com/4067311/41206925-f67f145c-6cd1-11e8-87eb-a716a9f734dd.png)

P.S: I have tested this only on macOS Sierra and theoretically should work on other operating systems as well. Let me know if it doesn't!