### PR TITLE
Pass app version info to internal APIs

### DIFF
--- a/src/renderer/redux/actions/user.js
+++ b/src/renderer/redux/actions/user.js
@@ -1,6 +1,6 @@
 import * as ACTIONS from 'constants/action_types';
 import Lbryio from 'lbryio';
-import { doNotify, MODALS } from 'lbry-redux';
+import { Lbry, doNotify, MODALS } from 'lbry-redux';
 import { doClaimRewardType, doRewardList } from 'redux/actions/rewards';
 import {
   selectEmailToVerify,
@@ -9,6 +9,7 @@ import {
 } from 'redux/selectors/user';
 import rewards from 'rewards';
 import analytics from 'analytics';
+import pjson from 'package.json';
 
 export function doFetchInviteStatus() {
   return dispatch => {
@@ -35,6 +36,21 @@ export function doFetchInviteStatus() {
   };
 }
 
+export function doInstallNew() {
+  return dispatch => {
+    const payload = {app_version: pjson.version};
+    Lbry.status().then(status => {
+      payload.app_id = status.installation_id;
+      Lbry.version().then(version => {
+        payload.daemon_version = version.lbrynet_version;
+        payload.platform = version.platform;
+        Lbryio.call('install', 'new', payload);
+      });
+    });
+  };
+}
+
+
 export function doAuthenticate() {
   return dispatch => {
     dispatch({
@@ -49,6 +65,7 @@ export function doAuthenticate() {
         });
         dispatch(doRewardList());
         dispatch(doFetchInviteStatus());
+        dispatch(doInstallNew());
       })
       .catch(error => {
         dispatch(doNotify({ id: MODALS.AUTHENTICATION_FAILURE }));

--- a/src/renderer/redux/actions/user.js
+++ b/src/renderer/redux/actions/user.js
@@ -43,6 +43,7 @@ export function doInstallNew() {
       payload.app_id = status.installation_id;
       Lbry.version().then(version => {
         payload.daemon_version = version.lbrynet_version;
+        payload.operating_system = version.os_system;
         payload.platform = version.platform;
         Lbryio.call('install', 'new', payload);
       });

--- a/src/renderer/redux/actions/user.js
+++ b/src/renderer/redux/actions/user.js
@@ -37,20 +37,17 @@ export function doFetchInviteStatus() {
 }
 
 export function doInstallNew() {
-  return dispatch => {
-    const payload = {app_version: pjson.version};
-    Lbry.status().then(status => {
-      payload.app_id = status.installation_id;
-      Lbry.version().then(version => {
-        payload.daemon_version = version.lbrynet_version;
-        payload.operating_system = version.os_system;
-        payload.platform = version.platform;
-        Lbryio.call('install', 'new', payload);
-      });
+  const payload = { app_version: pjson.version };
+  Lbry.status().then(status => {
+    payload.app_id = status.installation_id;
+    Lbry.version().then(version => {
+      payload.daemon_version = version.lbrynet_version;
+      payload.operating_system = version.os_system;
+      payload.platform = version.platform;
+      Lbryio.call('install', 'new', payload);
     });
-  };
+  });
 }
-
 
 export function doAuthenticate() {
   return dispatch => {
@@ -66,7 +63,7 @@ export function doAuthenticate() {
         });
         dispatch(doRewardList());
         dispatch(doFetchInviteStatus());
-        dispatch(doInstallNew());
+        doInstallNew();
       })
       .catch(error => {
         dispatch(doNotify({ id: MODALS.AUTHENTICATION_FAILURE }));


### PR DESCRIPTION
#1579 

Edit: This passes the platform returned by `Lbry.version` which for me is `Linux-4.15.0-23-generic-x86_64-with-Ubuntu-18.04-bionic`