### PR TITLE
Design Bug in light theme

### DIFF
--- a/static/themes/light.css
+++ b/static/themes/light.css
@@ -1,1 +1,6 @@
-:root {}
+:root {
+  
+  /* Text */
+--text-selection-color: var(--color-red);
+
+}


### PR DESCRIPTION
Background Color and Text-selection-color is same so when we select text for copy or something..

For example in white background white text became invisible..

To fix this problem i change the selection text color to red so when anyone select the text in light theme they see text in red color when they select the text..

![design bug](https://user-images.githubusercontent.com/11346292/41450967-3756df78-7088-11e8-9f42-ea7d1ebd0c3a.PNG)
