### PR TITLE
removed direct call to doLoadVideo for autoplay handling. 

### DIFF
--- a/src/renderer/component/video/index.js
+++ b/src/renderer/component/video/index.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import * as settings from 'constants/settings';
 import { doChangeVolume } from 'redux/actions/app';
 import { selectVolume } from 'redux/selectors/app';
-import { doPlayUri, doSetPlayingUri, doLoadVideo } from 'redux/actions/content';
+import { doPlayUri, doSetPlayingUri } from 'redux/actions/content';
 import { doPlay, doPause, savePosition } from 'redux/actions/media';
 import {
   makeSelectMetadataForUri,
@@ -38,7 +38,6 @@ const select = (state, props) => ({
 
 const perform = dispatch => ({
   play: uri => dispatch(doPlayUri(uri)),
-  load: uri => dispatch(doLoadVideo(uri)),
   cancelPlay: () => dispatch(doSetPlayingUri(null)),
   changeVolume: volume => dispatch(doChangeVolume(volume)),
   doPlay: () => dispatch(doPlay()),

--- a/src/renderer/component/video/view.jsx
+++ b/src/renderer/component/video/view.jsx
@@ -80,22 +80,11 @@ class Video extends React.PureComponent<Props> {
   }
 
   handleAutoplay = (props: Props) => {
-    const {
-      autoplay,
-      playingUri,
-      fileInfo,
-      costInfo,
-      isDownloading,
-      uri,
-      load,
-      play,
-      metadata,
-    } = props;
+    const { autoplay, playingUri, fileInfo, costInfo, isDownloading, uri, play, metadata } = props;
 
     const playable = autoplay && playingUri !== uri && metadata && !metadata.nsfw;
 
     if (playable && costInfo && costInfo.cost === 0 && !fileInfo && !isDownloading) {
-      load(uri);
       play(uri);
     } else if (playable && fileInfo && fileInfo.blobs_completed > 0) {
       play(uri);


### PR DESCRIPTION
This is already being called in the play. No reason to call it twice.