### PR TITLE
Revert "fixed isPlayable to only play for video or audio."

### DIFF
--- a/src/renderer/page/file/view.jsx
+++ b/src/renderer/page/file/view.jsx
@@ -116,7 +116,7 @@ class FilePage extends React.Component<Props> {
     const shouldObscureThumbnail = obscureNsfw && metadata.nsfw;
     const { height, channel_name: channelName, value } = claim;
     const mediaType = Lbry.getMediaType(contentType);
-    const isPlayable = mediaType === 'video' || mediaType === 'audio';
+    const isPlayable = Object.values(player.mime).includes(contentType) || mediaType === 'audio';
     const channelClaimId =
       value && value.publisherSignature && value.publisherSignature.certificateId;
     let subscriptionUri;


### PR DESCRIPTION
Reverts lbryio/lbry-app#1623

@tiger5226 reverting this because it's causing issues with images not being playable. I think the fix for that would be pretty easy but I'm not sure off the top of my head.