### PR TITLE
throttle fetchFeaturedUris

### DIFF
--- a/src/renderer/page/discover/view.jsx
+++ b/src/renderer/page/discover/view.jsx
@@ -9,9 +9,17 @@ type Props = {
   featuredUris: {},
 };
 
+let featuredUrisThrottled = false;
+
 class DiscoverPage extends React.PureComponent<Props> {
   componentWillMount() {
-    this.props.fetchFeaturedUris();
+    if (!featuredUrisThrottled) {
+      featuredUrisThrottled = true;
+      this.props.fetchFeaturedUris();
+      setTimeout(() => {
+        featuredUrisThrottled = false;
+      }, 1000 * 60 * 30);
+    }
   }
 
   render() {


### PR DESCRIPTION
#1048 

Throttles the `fetchFeaturedUris` action call in the `componentWillMount` lifecycle hook of the `<DiscoverPage>` component such that it is only called at most once every 30 minutes.