### PR TITLE
Block pointer events of disabled cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
    * URI and outpoint not being passed properly to API ([#1494](https://github.com/lbryio/lbry-app/issues/1494))
    * Incorrect markdown preview on url with parentheses ([#1570](https://github.com/lbryio/lbry-app/issues/1570))
    * Fix Linux upgrade path and add manual installation note ([#1606](https://github.com/lbryio/lbry-app/issues/1606))
+   * Fix can type in unfocused fields while publishing without selecting file ([#1456](https://github.com/lbryio/lbry-app/issues/1456))
    
    
    

--- a/src/renderer/scss/component/_card.scss
+++ b/src/renderer/scss/component/_card.scss
@@ -66,6 +66,7 @@
 
 .card--disabled {
   opacity: 0.3;
+  pointer-events: none;
 }
 
 .card__media {


### PR DESCRIPTION
## Changes
- Fix can type in unfocused fields while publishing without selecting file #1456