### PR TITLE
Fix incorrect page designation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
    * Pre-fill publish URL after clicking "Put something here" link ([#1303](https://github.com/lbryio/lbry-app/pull/1303))
    * Danger JS to automate code reviews ([#1289](https://github.com/lbryio/lbry-app/pull/1289))
    * 'Go to page' input on channel pagination ([#1166](https://github.com/lbryio/lbry-app/pull/1166))
-   
+
 ### Changed
    * LBRY App UI Redesign 5.0 implemented including new theme, layout, and improved search mechanics ([#870](https://github.com/lbryio/lbry-app/pull/870)) and ([#1173](https://github.com/lbryio/lbry-app/pull/1173))
    * Adapted dark mode to redesign ([#1269](https://github.com/lbryio/lbry-app/pull/1269))
@@ -32,7 +32,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
    * Made font in price badge larger ([#1420](https://github.com/lbryio/lbry-app/pull/1420))
    * Move rewards logic to interal api ([#1509](https://github.com/lbryio/lbry-app/pull/1509))
    * Narrative about Feature Request on Help Page and Report Page ([#1551](https://github.com/lbryio/lbry-app/pull/1551))
-   
+
 
 ### Fixed
    * Create channel and publish immediately([#1481](https://github.com/lbryio/lbry-app/pull/1481))
@@ -57,9 +57,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
    * Incorrect markdown preview on url with parentheses ([#1570](https://github.com/lbryio/lbry-app/issues/1570))
    * Fix Linux upgrade path and add manual installation note ([#1606](https://github.com/lbryio/lbry-app/issues/1606))
    * Fix can type in unfocused fields while publishing without selecting file ([#1456](https://github.com/lbryio/lbry-app/issues/1456))
-   
-   
-   
+   * Fix navigation button resulting incorrect page designation ([#1502](https://github.com/lbryio/lbry-app/issues/1502))
+
+
 ## [0.21.6] - 2018-06-05
 
 ### Fixed
@@ -80,9 +80,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
  * Rewards now rely on API data ([#1329](https://github.com/lbryio/lbry-app/issues/1329))
- 
- 
- 
+
+
+
 ## [0.21.4] - 2018-05-10
 
 ### Changed

--- a/src/renderer/page/channel/view.jsx
+++ b/src/renderer/page/channel/view.jsx
@@ -66,7 +66,7 @@ class ChannelPage extends React.PureComponent<Props> {
   render() {
     const { fetching, claimsInChannel, claim, page, totalPages } = this.props;
     const { name, permanent_url: permanentUrl, claim_id: claimId } = claim;
-
+    const currentPage = parseInt((page || 1) - 1, 10);
     let contentList;
     if (fetching) {
       contentList = <BusyIndicator message={__('Fetching content')} />;
@@ -104,7 +104,8 @@ class ChannelPage extends React.PureComponent<Props> {
                 breakClassName="pagination__item pagination__item--break"
                 marginPagesDisplayed={2}
                 onPageChange={e => this.changePage(e.selected + 1)}
-                initialPage={parseInt(page - 1, 10)}
+                forcePage={currentPage}
+                initialPage={currentPage}
                 containerClassName="pagination"
               />
 

--- a/src/renderer/scss/component/_pagination.scss
+++ b/src/renderer/scss/component/_pagination.scss
@@ -9,12 +9,12 @@
   line-height: $spacing-vertical * 1.5;
   height: $spacing-vertical * 1.5;
   border-radius: 2px;
-  &:not(.pagination__item--selected):hover {
+
+  &:not(.pagination__item--selected):not(.pagination__item--break):not(.disabled):hover {
     background: rgba(0, 0, 0, 0.2);
-    > a {
-      cursor: hand;
-    }
+    cursor: pointer;
   }
+
   > a {
     display: inline-block;
     padding: 0 $spacing-vertical * 2 / 3;


### PR DESCRIPTION
### Changes 
 Navigation button resulting incorrect page designation #1502 

> We can know that if the forcePage number still the same, the page will re-render, but won't change. So when you do your search function, you should reset the forcePage number.
https://github.com/AdeleD/react-paginate/issues/198#issuecomment-381465298