### PR TITLE
Spell Checker CSS Style Changes

### DIFF
--- a/src/renderer/scss/component/_markdown-editor.scss
+++ b/src/renderer/scss/component/_markdown-editor.scss
@@ -91,3 +91,9 @@ div.editor-toolbar a {
 .CodeMirror .CodeMirror-placeholder {
   opacity: 0.5;
 }
+.CodeMirror .cm-spell-error:not(.cm-url):not(.cm-comment):not(.cm-tag):not(.cm-word) {
+  background: none;
+  text-decoration: underline;
+  text-decoration-color: #f00;
+  text-decoration-style: dotted;
+}


### PR DESCRIPTION
These changes follow **typical** styling rules for **spelling errors** in **most** applications which means people are **familiar** with the **markup** which avoids **confusion**. The changes also mean that the incorrect spelling style is more **visible** especially in the **Dark theme** where it was almost impossible to see.

![image](https://user-images.githubusercontent.com/29914179/41820568-05356514-7817-11e8-9991-95e639223ef8.png)
