### PR TITLE
Description Correction For Community Top Bids Tooltip.

### DIFF
--- a/src/renderer/component/categoryList/view.jsx
+++ b/src/renderer/component/categoryList/view.jsx
@@ -225,7 +225,7 @@ class CategoryList extends React.PureComponent<Props, State> {
                 <ToolTip
                   label={__("What's this?")}
                   body={__(
-                    'Community Content is a public space where anyone can share content with the rest of the LBRY community. Bid on the names "one," "two," "three," "four" and "five" to put your content here!'
+                    'Community Content is a public space where anyone can share content with the rest of the LBRY community. Bid on the names from "one" to "ten" to put your content here!'
                   )}
                 />
               )}


### PR DESCRIPTION
Corrections on the `tooltip` detailing that you can bid on **one to ten**, not **one to five**.

![image](https://user-images.githubusercontent.com/29914179/41820892-21e7c184-781c-11e8-8101-ea408ce285e2.png)
