### PR TITLE
2nd Column Lost it's Colour

### DIFF
--- a/src/renderer/scss/component/_table.scss
+++ b/src/renderer/scss/component/_table.scss
@@ -86,6 +86,7 @@ table.table--help {
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
+    color: var(--color-help);
   }
 }
 


### PR DESCRIPTION
When the new code was added the `var(--color-help)` was lost and it defaulted back to **brash white**. This adds the `var(--color-help)` back in.

### BEFORE

![image](https://user-images.githubusercontent.com/29914179/41971085-9fae1a38-7a50-11e8-9b9a-81c8f247f561.png)

### AFTER

![image](https://user-images.githubusercontent.com/29914179/41971104-a9499e6e-7a50-11e8-8534-dbf1f59eed8c.png)
