### PR TITLE
use claimName instead of uri while loading channel page

### DIFF
--- a/src/renderer/page/show/view.jsx
+++ b/src/renderer/page/show/view.jsx
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import { parseURI } from 'lbry-redux';
 import BusyIndicator from 'component/common/busy-indicator';
 import ChannelPage from 'page/channel';
 import FilePage from 'page/file';
@@ -39,10 +40,11 @@ class ShowPage extends React.PureComponent<Props> {
     let innerContent = '';
 
     if ((isResolvingUri && !claim) || !claim) {
+      const { claimName } = parseURI(uri);
       innerContent = (
         <Page>
           <section className="card">
-            <h1>{uri}</h1>
+            <h1>{claimName}</h1>
             <div className="card__content">
               {isResolvingUri && <BusyIndicator message={__('Loading decentralized data...')} />}
               {claim === null &&


### PR DESCRIPTION
### Before

![before](https://user-images.githubusercontent.com/16882830/42016105-2ca45048-7a78-11e8-8386-5a3cc1815585.gif)

### After
![after](https://user-images.githubusercontent.com/16882830/42016107-324ea2a0-7a78-11e8-9a7f-05ecb82b5281.gif)
