### PR TITLE
fix 1713: set button links to 'display: inline'

### DIFF
--- a/src/renderer/scss/component/_button.scss
+++ b/src/renderer/scss/component/_button.scss
@@ -62,11 +62,11 @@ button:disabled {
   font-size: 1em;
   color: var(--btn-color-inverse);
   border-radius: 0;
-  display: inline-block;
+  display: inline;
   min-width: 0;
   box-shadow: none;
   text-align: left;
-/*Tourniquets text over 20VW*/
+  /*Tourniquets text over 20VW*/
   max-width: 20vw;
   white-space: nowrap;
   overflow: hidden;


### PR DESCRIPTION
#1713 
After setting `overflow: hidden`, it changes the way height works for block elements.

https://stackoverflow.com/questions/22421782/css-overflow-hidden-increases-height-of-container

Setting to `inline` fixes this.