### PR TITLE
Fix 1698

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -83,7 +83,9 @@ app.on('ready', async () => {
 });
 
 app.on('activate', () => {
-  rendererWindow.show();
+  if (rendererWindow) {
+    rendererWindow.show();
+  }
 });
 
 app.on('will-quit', event => {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -122,6 +122,10 @@ app.on('will-quit', event => {
     daemon.quit();
     event.preventDefault();
   }
+
+  if (rendererWindow) {
+    rendererWindow = null;
+  }
 });
 
 // https://electronjs.org/docs/api/app#event-will-finish-launching


### PR DESCRIPTION
After fixing the show error, I then received "this object has been destroyed already" if reopening too quickly. The 2nd commit fixes that. It just won't open if you try it too quickly (while LBRY is still shutting down) - not sure we can do much about that at without a larger refactor. 