### PR TITLE
Handle LBC unavailable error from ShapeShift without breaking the app

### DIFF
--- a/src/renderer/component/shapeShift/internal/active-shift.jsx
+++ b/src/renderer/component/shapeShift/internal/active-shift.jsx
@@ -56,7 +56,7 @@ class ActiveShapeShift extends React.PureComponent<Props> {
     }
   }
 
-  continousFetch: ?number;
+  continousFetch: ?IntervalID;
 
   render() {
     const {
@@ -135,8 +135,8 @@ class ActiveShapeShift extends React.PureComponent<Props> {
         {shiftState === statuses.NO_DEPOSITS &&
           shiftReturnAddress && (
             <div className="help">
-              If the transaction doesn't go through, ShapeShift will return your {shiftCoinType}{' '}
-              back to {shiftReturnAddress}
+              {__("If the transaction doesn't go through, ShapeShift will return your")}{' '}
+              {shiftCoinType} {__('back to')} {shiftReturnAddress}
             </div>
           )}
       </div>

--- a/src/renderer/constants/shape_shift.js
+++ b/src/renderer/constants/shape_shift.js
@@ -1,3 +1,5 @@
 export const NO_DEPOSITS = 'no_deposits';
 export const RECEIVED = 'received';
 export const COMPLETE = 'complete';
+export const AVAILABLE = 'available';
+export const UNAVAILABLE = 'unavailable';

--- a/src/renderer/redux/actions/shape_shift.js
+++ b/src/renderer/redux/actions/shape_shift.js
@@ -1,5 +1,6 @@
 // @flow
 import Promise from 'bluebird';
+import * as SHAPESHIFT_STATUSES from 'constants/shape_shift';
 import * as ACTIONS from 'constants/action_types';
 import { coinRegexPatterns } from 'util/shape_shift';
 import type {
@@ -65,9 +66,15 @@ export const shapeShiftInit = () => (dispatch: Dispatch): ThunkAction => {
   return shapeShift
     .coinsAsync()
     .then(coinData => {
+      if (coinData.LBC.status === SHAPESHIFT_STATUSES.UNAVAILABLE) {
+        return dispatch({
+          type: ACTIONS.GET_SUPPORTED_COINS_FAIL,
+        });
+      }
+
       let supportedCoins = [];
       Object.keys(coinData).forEach(symbol => {
-        if (coinData[symbol].status === 'available') {
+        if (coinData[symbol].status === SHAPESHIFT_STATUSES.UNAVAILABLE) {
           supportedCoins.push(coinData[symbol]);
         }
       });
@@ -81,7 +88,7 @@ export const shapeShiftInit = () => (dispatch: Dispatch): ThunkAction => {
         type: ACTIONS.GET_SUPPORTED_COINS_SUCCESS,
         data: supportedCoins,
       });
-      dispatch(getCoinStats(supportedCoins[0]));
+      return dispatch(getCoinStats(supportedCoins[0]));
     })
     .catch(err => dispatch({ type: ACTIONS.GET_SUPPORTED_COINS_FAIL, data: err }));
 };

--- a/src/renderer/redux/reducers/shape_shift.js
+++ b/src/renderer/redux/reducers/shape_shift.js
@@ -117,7 +117,7 @@ export default handleActions(
     [ACTIONS.GET_SUPPORTED_COINS_FAIL]: (state: ShapeShiftState): ShapeShiftState => ({
       ...state,
       loading: false,
-      error: 'Error getting available coins',
+      error: __('There was an error. Please try again later.'),
     }),
 
     [ACTIONS.GET_COIN_STATS_START]: (


### PR DESCRIPTION
If LBC is unavailable on shapeshift (like it is right now) the app breaks on the Get Credits page. We need to explicitly check that it is available before worrying about other coins availability.

If it's unavailable, stop and show an error message.